### PR TITLE
Fixup

### DIFF
--- a/build_guides/architeuthis_dux.md
+++ b/build_guides/architeuthis_dux.md
@@ -17,12 +17,10 @@ thumbnail: https://i.imgur.com/VhvY3Do.png
 ### Required 
 | Item | Count |
 |------|-------|
-| SMD Diodes | 30 |
 | PCB | 2 |
 | Promicro-style or similar microcontroller | 2 |
 | TRRS Jack | 2 | 
-| TRRS Cable | 1 | 
-| Reset Switch | 2 | 
+| TRRS Cable | 1 |  
 | Choc Hotswap Sockets | 30 | 
 | Choc Switches | 30 | 
 | *Choc* Keycaps | 30 |


### PR DESCRIPTION
This appears to be a copy paste issue. This does not appear to use diodes or reset switches on this board, at least as far as the guide shows, so they were removed from the list.