### PR TITLE
fix: Build guides all formatted, and links

### DIFF
--- a/build_guides/3x4.md
+++ b/build_guides/3x4.md
@@ -16,159 +16,355 @@ thumbnail: https://boardsource.imgix.net/bcd9a296-b7db-4625-b3d4-6248c551c4c1.jp
 
 
 ## Kit Contents
-* [3x4 Ortho Plaid-Style PCB (1)](https://boardsource.xyz/store/5ecc2008eee64242946c98c1)
+* [3x4 Ortho Plaid-Style PCB
+  (1)](https://boardsource.xyz/store/5ecc2008eee64242946c98c1)
 * FR4 Backplate (1)
 * 3x4 FR4 Plate (1)
-* [Elite-C / Pro Micro (optional) (1)](https://boardsource.xyz/store/5eca03e264caf04f83aa6476)
+* [Elite-C / Pro Micro (optional)
+  (1)](https://boardsource.xyz/store/5eca03e264caf04f83aa6476)
 * Acrylic Cover (1)
 * Threaded Standoffs (7)
 * [M2 Screws (14)](https://boardsource.xyz/store/5ecad60fe7e0515b382b553b)
 * [Diodes (12)](https://boardsource.xyz/store/5ec9fc5d64caf04f83aa646c)
-* [Hotswap Sockets (optional) (12)](https://boardsource.xyz/store/5eca066464caf04f83aa647f)
+* [Hotswap Sockets (optional)
+  (12)](https://boardsource.xyz/store/5eca066464caf04f83aa647f)
 * Rubber Feet (4)
 
 # Step 1: Check Kit Contents
-![photo of kit laid out](https://boardsource.imgix.net/e66b7626-7ba0-46ae-ab3f-68c821f9f61b.jpg)
+![photo of kit laid
+out](https://boardsource.imgix.net/e66b7626-7ba0-46ae-ab3f-68c821f9f61b.jpg)
 
-Prior to starting any build it is important to take a look at what you received and what you have in front of you. Not much is more frustrating than getting halfway through a build and realizing you’re missing a single hotswap socket or a screw, or anything for that matter. If you think we forgot to ship something, or if you may have accidentally misplaced something, please reach out to us on [Discord](https://discord.gg/FTun6Cy) in the Help section, or [Submit A Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account section of Boardsource. 
+Prior to starting any build it is important to take a look at what you received
+and what you have in front of you. Not much is more frustrating than getting
+halfway through a build and realizing you’re missing a single hotswap socket or
+a screw, or anything for that matter. If you think we forgot to ship something,
+or if you may have accidentally misplaced something, please reach out to us on
+[Discord](https://discord.gg/FTun6Cy) in the Help section, or [Submit A
+Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account
+section of Boardsource.
 
-Note: Boardsource often includes extras of certain items in our kits, it is not unusual to have an extra screw, hotswap socket, or diode. The quantities listed in the Kit Contents section at the beginning of this guide are the true accurate number of components needed to complete the build, if you have more than the listed quantities or have some left over at the end it does not mean that you forgot something or built the kit improperly.
+Note: Boardsource often includes extras of certain items in our kits, it is not
+unusual to have an extra screw, hotswap socket, or diode. The quantities listed
+in the Kit Contents section at the beginning of this guide are the true accurate
+number of components needed to complete the build, if you have more than the
+listed quantities or have some left over at the end it does not mean that you
+forgot something or built the kit improperly.
 
 # Step 2: Assemble the PCB
 
 ## PCB Assembly - Prepare Hotswap Sockets
-![photo of hotswap socket placement](https://boardsource.imgix.net/9b635f02-14fa-4e23-b39a-855c46619e3e.jpg)
+![photo of hotswap socket
+placement](https://boardsource.imgix.net/9b635f02-14fa-4e23-b39a-855c46619e3e.jpg)
 
-Place each hotswap socket into the designated place on the PCB. Hotswap sockets go on the back of the PCB. The front of the PCB is indicated by the white markings indicating the placement of the diodes, and the back of the PCB is indicated by having solder points for the hotswap sockets.
+Place each hotswap socket into the designated place on the PCB. Hotswap sockets
+go on the back of the PCB. The front of the PCB is indicated by the white
+markings indicating the placement of the diodes, and the back of the PCB is
+indicated by having solder points for the hotswap sockets.
 
-Match up the solder points to the solder pads on the back of the PCB, you will know that the hotswap socket is oriented properly because no portion of the socket should overlap the hole in-between the pads that allows for a switch post to pass through. If your sockets are oriented improperly they intersect that hole and your switch won’t sit properly. See note below…
+Match up the solder points to the solder pads on the back of the PCB, you will
+know that the hotswap socket is oriented properly because no portion of the
+socket should overlap the hole in-between the pads that allows for a switch post
+to pass through. If your sockets are oriented improperly they intersect that
+hole and your switch won’t sit properly. See note below…
 
-I like to place every hotswap socket prior to soldering, and then solder them all at once, but it is your decision on the order of operations there.
+I like to place every hotswap socket prior to soldering, and then solder them
+all at once, but it is your decision on the order of operations there.
 
-Note: I realize this is ridiculous considering this is a build guide, but two of the hotswap sockets in the photos shown are oriented incorrectly, they are upside down. I was very tired when doing this build and I wasn’t used to doing it for a camera, but let this be a lesson that it is important to go slowly, take your time, and check your build at every stage and every step. It’s easier to fix an issue immediately when you notice it instead of many steps down the line. In my photos showing hotswap sockets, majority rules, the majority of the hotswap sockets are oriented properly so mimic that and ignore the two outliers. All hotswap sockets should be facing the same direction and oriented the same, _unlike_ the example photos.
+Note: I realize this is ridiculous considering this is a build guide, but two of
+the hotswap sockets in the photos shown are oriented incorrectly, they are
+upside down. I was very tired when doing this build and I wasn’t used to doing
+it for a camera, but let this be a lesson that it is important to go slowly,
+take your time, and check your build at every stage and every step. It’s easier
+to fix an issue immediately when you notice it instead of many steps down the
+line. In my photos showing hotswap sockets, majority rules, the majority of the
+hotswap sockets are oriented properly so mimic that and ignore the two outliers.
+All hotswap sockets should be facing the same direction and oriented the same,
+_unlike_ the example photos.
 
 ## PCB Assembly - Solder Hotswap Sockets
-![photo of completed hotswap sockets](https://boardsource.imgix.net/95ca9956-66e0-464b-b2ed-0a1f0d5cb6ba.jpg)
-Each hotswap socket needs to be soldered in two locations, one on each side of the socket next to where each of the switch legs go.
+![photo of completed hotswap
+sockets](https://boardsource.imgix.net/95ca9956-66e0-464b-b2ed-0a1f0d5cb6ba.jpg)
+Each hotswap socket needs to be soldered in two locations, one on each side of
+the socket next to where each of the switch legs go.
 
-Pro Tip: I like to use a little extra solder when I solder hotswap sockets, don’t go crazy though, just a tiny bit more than you may be inclined to use is enough extra. My logic is that because these take a fair bit of pressure when installing switches, especially if a switch leg is bent, it is easy to put a fair amount of force on the hotswap socket and the extra solder will help to ensure strength.
+Pro Tip: I like to use a little extra solder when I solder hotswap sockets,
+don’t go crazy though, just a tiny bit more than you may be inclined to use is
+enough extra. My logic is that because these take a fair bit of pressure when
+installing switches, especially if a switch leg is bent, it is easy to put a
+fair amount of force on the hotswap socket and the extra solder will help to
+ensure strength.
 
 
 ## PCB Assembly - Prepare (Bend) Diodes
-![photo of diodes being prepped](https://boardsource.imgix.net/0f26d3a4-685d-47d5-aeb4-6591eb95eec1.jpg)
+![photo of diodes being
+prepped](https://boardsource.imgix.net/0f26d3a4-685d-47d5-aeb4-6591eb95eec1.jpg)
 
-Each diode is shipped “straight" and unbent, or at least relatively unbent compared to how we want them. You must separate each of the diodes from the strip (currently all Boardsource diodes are shipped in a strip) and bend each individually. Depending on the application, I sometimes use a Diode Bender to prep my diodes, but because the 3x4 Macro pad displays the diodes so prominently, I would opt to do it by hand. I feel that bending the diodes by hand allows for more control and less mistakes overall. I always try to bend them each equally so they line up as even as possible on the front of the board. If you don’t take your time to bend the diodes nicely it may not look at uniform on the front of the board. However, some people don’t care about these things as much as me, and no matter how much or little time you spend on this step, the 3x4 Macro Pad will work all the same.
+Each diode is shipped “straight" and unbent, or at least relatively unbent
+compared to how we want them. You must separate each of the diodes from the
+strip (currently all Boardsource diodes are shipped in a strip) and bend each
+individually. Depending on the application, I sometimes use a Diode Bender to
+prep my diodes, but because the 3x4 Macro pad displays the diodes so
+prominently, I would opt to do it by hand. I feel that bending the diodes by
+hand allows for more control and less mistakes overall. I always try to bend
+them each equally so they line up as even as possible on the front of the board.
+If you don’t take your time to bend the diodes nicely it may not look at uniform
+on the front of the board. However, some people don’t care about these things as
+much as me, and no matter how much or little time you spend on this step, the
+3x4 Macro Pad will work all the same.
 
-While you’re doing this, notice that one half of the diode glass is indicated by a black stripe.
+While you’re doing this, notice that one half of the diode glass is indicated by
+a black stripe.
 
 ## PCB Assembly - Place Diodes
-![photo of diodes placed through the PCB with the legs on the reverse side bent](https://boardsource.imgix.net/7b5507d9-8af9-4490-9cbf-fb44cb62d69a.jpg)
+![photo of diodes placed through the PCB with the legs on the reverse side
+bent](https://boardsource.imgix.net/7b5507d9-8af9-4490-9cbf-fb44cb62d69a.jpg)
 
-After our diodes are prepared, we can place them into the PCB. The black and orange glass part of the diode goes on to the front of the PCB. You can tell the front of the PCB on the 3x4 Macro in two ways, first, it is the side which has the white (or black if your PCB is white) markings that surround the diode (the glass part) and also because the hotswap sockets go on the back of the PCB. 
+After our diodes are prepared, we can place them into the PCB. The black and
+orange glass part of the diode goes on to the front of the PCB. You can tell the
+front of the PCB on the 3x4 Macro in two ways, first, it is the side which has
+the white (or black if your PCB is white) markings that surround the diode (the
+glass part) and also because the hotswap sockets go on the back of the PCB.
 
-These markings are created by what is called "solder mask" and this solder mask (white on most PCBs, black on white PCBs) is often used to create pictures, give credit to designers or developers, or anything else really. The solder mask is essentially printing on to the PCB. A very common purpose for solder mask is to give hints about placement of components as well as orientation of components. The 3x4 Macro Pad is a great example of this because the white marking tell us where the diodes go, and also how we orient the diodes.
+These markings are created by what is called "solder mask" and this solder mask
+(white on most PCBs, black on white PCBs) is often used to create pictures, give
+credit to designers or developers, or anything else really. The solder mask is
+essentially printing on to the PCB. A very common purpose for solder mask is to
+give hints about placement of components as well as orientation of components.
+The 3x4 Macro Pad is a great example of this because the white marking tell us
+where the diodes go, and also how we orient the diodes.
 
-You will notice that each diode spot, of which there are 12, is outlined with a white box. The white box has a thicker white line on one end (the bottom when the PCB faces the direction of the product photos) and that thicker white line is also on the side of the diode where the leg passes through a square shaped hole, instead of the circular shaped hole on the other side. The shape of hole in a PCB is another way to indicate component orientation. The 3x4 Macro Pad uses two strategies to show which direction the diodes face: the thicker white line on one end of the box made by solder mask, as well as a square shaped hole on that side as opposed to a circular shaped hole.
+You will notice that each diode spot, of which there are 12, is outlined with a
+white box. The white box has a thicker white line on one end (the bottom when
+the PCB faces the direction of the product photos) and that thicker white line
+is also on the side of the diode where the leg passes through a square shaped
+hole, instead of the circular shaped hole on the other side. The shape of hole
+in a PCB is another way to indicate component orientation. The 3x4 Macro Pad
+uses two strategies to show which direction the diodes face: the thicker white
+line on one end of the box made by solder mask, as well as a square shaped hole
+on that side as opposed to a circular shaped hole.
 
-It is very easy to tell which direction to place the diodes after we know our way around the markings. The glass potion of the diode has a black strip on one end, and the body is mainly orange. The black portion of the diode goes towards the thick portion of the white solder mask and the leg on the black side of the diode glass goes into the square shaped hole. 
+It is very easy to tell which direction to place the diodes after we know our
+way around the markings. The glass potion of the diode has a black strip on one
+end, and the body is mainly orange. The black portion of the diode goes towards
+the thick portion of the white solder mask and the leg on the black side of the
+diode glass goes into the square shaped hole.
 
-In short, the black part of the diode glass points towards the square shaped hole.
+In short, the black part of the diode glass points towards the square shaped
+hole.
 
-**Pro Tip: Only do a single row/column at a time for the cleanest final product, while applying pressure to the glass part of the diode on the front of the board, bend the legs on the reverse side of the PCB outwards to create tension. This helps to hold the diode in place when you flip the PCB over to solder.**
+**Pro Tip: Only do a single row/column at a time for the cleanest final product,
+while applying pressure to the glass part of the diode on the front of the
+board, bend the legs on the reverse side of the PCB outwards to create tension.
+This helps to hold the diode in place when you flip the PCB over to solder.**
 
-![try to get an image in here of the bent legs on the reverse side](https://boardsource.imgix.net/bb9b1176-0d1a-49b0-b459-33605bb126d0.jpg)
+![try to get an image in here of the bent legs on the reverse
+side](https://boardsource.imgix.net/bb9b1176-0d1a-49b0-b459-33605bb126d0.jpg)
 
 
 ## PCB Assembly - Solder Diodes In Place
 
-![photo of diodes totally done](https://boardsource.imgix.net/70d1ca3b-b804-4ab5-8c4e-088f55104572.jpg)
+![photo of diodes totally
+done](https://boardsource.imgix.net/70d1ca3b-b804-4ab5-8c4e-088f55104572.jpg)
 
-After you have placed all the diodes in the correct position and soldered each of the legs in place, check both sides of the PCB for errors. Carefully check over each of the diodes on the front to ensure that each are oriented correctly, with the black portion of the diode glass facing the square shaped hole, and that each of the legs on the back are soldered in.
+After you have placed all the diodes in the correct position and soldered each
+of the legs in place, check both sides of the PCB for errors. Carefully check
+over each of the diodes on the front to ensure that each are oriented correctly,
+with the black portion of the diode glass facing the square shaped hole, and
+that each of the legs on the back are soldered in.
 
-Make sure to check each diode very carefully to ensure it is soldered and oriented properly prior to cutting the extra length of the legs off from the back of the PCB. It is easier to fix a mistake before the legs are trimmed.
+Make sure to check each diode very carefully to ensure it is soldered and
+oriented properly prior to cutting the extra length of the legs off from the
+back of the PCB. It is easier to fix a mistake before the legs are trimmed.
 
 ## PCB Assembly - Complete
-![photo of completed PCB assembly](https://boardsource.imgix.net/62d5cc89-46ca-4236-b9b1-6db3d0991472.jpg)
+![photo of completed PCB
+assembly](https://boardsource.imgix.net/62d5cc89-46ca-4236-b9b1-6db3d0991472.jpg)
 
-Now that you have installed the hotswap sockets and diodes, the assembly of the PCB is complete for the 3x4 Macro Pad. Make sure to do another review of your work to make sure it is correct before moving on.
+Now that you have installed the hotswap sockets and diodes, the assembly of the
+PCB is complete for the 3x4 Macro Pad. Make sure to do another review of your
+work to make sure it is correct before moving on.
 
 # Step 3: Prep and Place the Micro Controller
-Note: The 3x4 Macro Pad is compatible with either an Elite-C or a Pro Micro, and you are able to purchase either micro controller with your kit from Boardsource. This guide uses an Elite-C but the installation steps are the _exact_ same for a Pro Micro.
+Note: The 3x4 Macro Pad is compatible with either an Elite-C or a Pro Micro, and
+you are able to purchase either micro controller with your kit from Boardsource.
+This guide uses an Elite-C but the installation steps are the _exact_ same for a
+Pro Micro.
 
-Important: If you are using a Pro Micro in your build, flash your keymap to your Pro Micro before doing anything else. Pro Micros do not have an on-board reset switch and neither does the 3x4 Macro Pad, so it will be hard to reset your Pro Micro in order to flash it after it is all assembled. By default, all boardsource_3x4 keymaps come with a Reset mapped. You can activate this by holding down the top left key of your macro pad /while_ plugging it in.
+Important: If you are using a Pro Micro in your build, flash your keymap to your
+Pro Micro before doing anything else. Pro Micros do not have an on-board reset
+switch and neither does the 3x4 Macro Pad, so it will be hard to reset your Pro
+Micro in order to flash it after it is all assembled. By default, all
+boardsource_3x4 keymaps come with a Reset mapped. You can activate this by
+holding down the top left key of your macro pad /while_ plugging it in.
 
-**Pro Tip: Prior to moving forward with this guide, you should flash your map to your micro controller no matter the style of micro controller you are using. Like anything, sometimes micro controllers break or are dead on arrival. It is very frustrating to complete a build, assume everything works, and then go to flash your map only to be surprised that the micro controller is broken. It is not a common occurrence at all so don’t be too concerned, I have actually never personally encountered a broken micro controller, but is is best practice to do a test flash prior to using one in your build just to make sure it’s good to go.**
+**Pro Tip: Prior to moving forward with this guide, you should flash your map to
+your micro controller no matter the style of micro controller you are using.
+Like anything, sometimes micro controllers break or are dead on arrival. It is
+very frustrating to complete a build, assume everything works, and then go to
+flash your map only to be surprised that the micro controller is broken. It is
+not a common occurrence at all so don’t be too concerned, I have actually never
+personally encountered a broken micro controller, but is is best practice to do
+a test flash prior to using one in your build just to make sure it’s good to
+go.**
 
 ## Solder Legs to the Micro Controller
-![photo of legs of micro controller](https://boardsource.imgix.net/36498bcb-76f1-4cbb-a5ed-0b83853c68dd.jpg)
+![photo of legs of micro
+controller](https://boardsource.imgix.net/36498bcb-76f1-4cbb-a5ed-0b83853c68dd.jpg)
 
-In order to use the micro controller on your board, you must first prep the micro controller for installation. This process is essentially the same for every keyboard, you must solder the legs onto the micro controller. Elite-Cs and Pro Micros come with legs in the anti-static baggie. There is usually 3 sets, 2 long and 1 short. We don’t use the short, but we will use the 2 long sections.
+In order to use the micro controller on your board, you must first prep the
+micro controller for installation. This process is essentially the same for
+every keyboard, you must solder the legs onto the micro controller. Elite-Cs and
+Pro Micros come with legs in the anti-static baggie. There is usually 3 sets, 2
+long and 1 short. We don’t use the short, but we will use the 2 long sections.
 
-Micro controller leg sections have a black plastic strip connecting them, and that strip is not placed directly in the center of the leg. This placement creates a “short” end and a “long” end. The long end is what goes through the PCB and the short end is what comes up through the micro controller. On the 3x4 Macro Pad the micro controller is installed with the component’s facing up. On the Elite-C this means the reset button is facing upwards. Make sure you solder yours legs in place exactly as shown in the image above, as well as the completed product photos throughout the website. If you install the micro controller upside down, your keymap will not work as you’d expect. Additionally, micro controllers are one of the most annoying things to desolder and fix, so try very hard to get it right the first time.
+Micro controller leg sections have a black plastic strip connecting them, and
+that strip is not placed directly in the center of the leg. This placement
+creates a “short” end and a “long” end. The long end is what goes through the
+PCB and the short end is what comes up through the micro controller. On the 3x4
+Macro Pad the micro controller is installed with the component’s facing up. On
+the Elite-C this means the reset button is facing upwards. Make sure you solder
+yours legs in place exactly as shown in the image above, as well as the
+completed product photos throughout the website. If you install the micro
+controller upside down, your keymap will not work as you’d expect. Additionally,
+micro controllers are one of the most annoying things to desolder and fix, so
+try very hard to get it right the first time.
 
-When soldering the legs to the micro controller, make sure that the legs are at a 90 deg angle to the micro controller and that they are straight the entire length, and inserted all the way. If you don’t take the time to ensure everything is lined up properly and not crooked/diagonal it is likely that you won’t be able to install the micro controller because the legs won’t line up with the holes on the PCB. Again, these are very annoying to desolder and fix so it is important to take your time and try to get it right the first time.
+When soldering the legs to the micro controller, make sure that the legs are at
+a 90 deg angle to the micro controller and that they are straight the entire
+length, and inserted all the way. If you don’t take the time to ensure
+everything is lined up properly and not crooked/diagonal it is likely that you
+won’t be able to install the micro controller because the legs won’t line up
+with the holes on the PCB. Again, these are very annoying to desolder and fix so
+it is important to take your time and try to get it right the first time.
 
-I hold the legs in place, fill my soldering iron with some solder, and then messily “tack” the legs in place in two locations. This basically means I just try to slop some solder onto the legs in two locations to make them stick. It isn’t super pretty, but it is easily cleaned up and can be made to look perfect again. At first you just need to get the legs to stick where you want, then you can move the micro controller, reposition it, and solder the remaining points in a more comfortable way.
+I hold the legs in place, fill my soldering iron with some solder, and then
+messily “tack” the legs in place in two locations. This basically means I just
+try to slop some solder onto the legs in two locations to make them stick. It
+isn’t super pretty, but it is easily cleaned up and can be made to look perfect
+again. At first you just need to get the legs to stick where you want, then you
+can move the micro controller, reposition it, and solder the remaining points in
+a more comfortable way.
 
 ## Install Micro Controller
 
-Now that our micro controller is prepped and the legs are soldered in place we can install it on to the PCB, which is also done being assembled. The 3x4 Macro Pad uses a zipper-style micro controller connection. Look closely at the holes where the micro controller goes, and you’ll notice they are staggered. This is intentional, and allows you to friction-fit the micro controller on to the PCB.  The zipper-style connection is hugely beneficial because it allows you to connect your micro controller without soldering, making it hot swappable without any extra components. Because micro controllers are so difficult to desolder and remove, this is a really great feature. Shoutout to Danny at Keeb.io for originating this idea and making this footprint.
+Now that our micro controller is prepped and the legs are soldered in place we
+can install it on to the PCB, which is also done being assembled. The 3x4 Macro
+Pad uses a zipper-style micro controller connection. Look closely at the holes
+where the micro controller goes, and you’ll notice they are staggered. This is
+intentional, and allows you to friction-fit the micro controller on to the PCB.
+The zipper-style connection is hugely beneficial because it allows you to
+connect your micro controller without soldering, making it hot swappable without
+any extra components. Because micro controllers are so difficult to desolder and
+remove, this is a really great feature. Shoutout to Danny at Keeb.io for
+originating this idea and making this footprint.
 
-Because the zipper-style connection is a friction-fit connection it can sometimes be difficult to get the micro controller installed the very first time. Do not try to push the entire thing into place all in one go; instead, tilt the controller and start on one side, applying slight pressure and “walking” it in to place. It takes a bit of getting used to but once you do it once it becomes much easier. 
+Because the zipper-style connection is a friction-fit connection it can
+sometimes be difficult to get the micro controller installed the very first
+time. Do not try to push the entire thing into place all in one go; instead,
+tilt the controller and start on one side, applying slight pressure and
+“walking” it in to place. It takes a bit of getting used to but once you do it
+once it becomes much easier.
 
-Note: If for some reason you hate the idea of the zipper-connection you are of course able to solder the micro controller in place.
+Note: If for some reason you hate the idea of the zipper-connection you are of
+course able to solder the micro controller in place.
 
 ## Cut Extra Leg Length Off Micro Controller
 
-After mastering the zipper-connection and successfully installing your micro controller, push on the top of the micro controller to ensure that it is firmly seated against the PCB, it should be completely even and only small gaps between the black plastic of the legs and the PCB. Don’t force it but do firmly press it into the PCB. 
+After mastering the zipper-connection and successfully installing your micro
+controller, push on the top of the micro controller to ensure that it is firmly
+seated against the PCB, it should be completely even and only small gaps between
+the black plastic of the legs and the PCB. Don’t force it but do firmly press it
+into the PCB.
 
-On the back of the PCB, there is the extra length of the micro controller legs, trim off the extra legs but do NOT trim it completely flush with the PCB. You only need to take off approx. 2mm in order to work properly here, and if you trim it flush with the PCB it may reduce the integrity of the zipper-connection. If we do not trim the legs at all, it will cause the connector of some micro controllers to press against the acrylic cover and raise it slightly, which is not a great look.
+On the back of the PCB, there is the extra length of the micro controller legs,
+trim off the extra legs but do NOT trim it completely flush with the PCB. You
+only need to take off approx. 2mm in order to work properly here, and if you
+trim it flush with the PCB it may reduce the integrity of the zipper-connection.
+If we do not trim the legs at all, it will cause the connector of some micro
+controllers to press against the acrylic cover and raise it slightly, which is
+not a great look.
 
-**Pro Tip: Be careful when cutting these legs down, they are quite rigid and that means when you cut off a small length of them it can go flying. Cover it with your hand when you cut so it flies up into your hand, and not into your eye or across the room for you to step on 20 minutes later.**
+**Pro Tip: Be careful when cutting these legs down, they are quite rigid and
+that means when you cut off a small length of them it can go flying. Cover it
+with your hand when you cut so it flies up into your hand, and not into your eye
+or across the room for you to step on 20 minutes later.**
 
 ## Micro Controller Install Complete
 
-Now we are done with all the hard parts, and short of any mistakes, you won’t need to use the soldering iron again for the rest of the build. 
+Now we are done with all the hard parts, and short of any mistakes, you won’t
+need to use the soldering iron again for the rest of the build.
 
-We have installed hotswap sockets and diodes on to the PCB, and we have prepped and installed  our micro controller to the PCB. Let’s move on to final assembly.
+We have installed hotswap sockets and diodes on to the PCB, and we have prepped
+and installed our micro controller to the PCB. Let’s move on to final assembly.
 
 # Step 4: Final Assembly
-Note: Be careful when using the threaded standoffs and M2 screws to not force anything in to place. They are very easy to strip. Do not over tighten.
+Note: Be careful when using the threaded standoffs and M2 screws to not force
+anything in to place. They are very easy to strip. Do not over tighten.
 
 ## Connect Standoffs to the Backplate
-![photo of standoff into backplate](https://boardsource.imgix.net/1861ec8b-06a7-4ae9-8bff-d862e4ccf385.jpg)
+![photo of standoff into
+backplate](https://boardsource.imgix.net/1861ec8b-06a7-4ae9-8bff-d862e4ccf385.jpg)
 
-The first step of final assembly is to connect 4 threaded standoffs to the back plate of the macro pad. This is done by inserting a screw in through the bottom of the backplate and then threading a standoff to the front. Do this for all four lower holes in the backplate.
+The first step of final assembly is to connect 4 threaded standoffs to the back
+plate of the macro pad. This is done by inserting a screw in through the bottom
+of the backplate and then threading a standoff to the front. Do this for all
+four lower holes in the backplate.
 
 ## Connect Standoffs for Acrylic to the PCB
-![photo of acrylic standoffs on PCB](https://boardsource.imgix.net/8babcf64-9bcc-41dd-9cec-43da4c48504f.jpg)
+![photo of acrylic standoffs on
+PCB](https://boardsource.imgix.net/8babcf64-9bcc-41dd-9cec-43da4c48504f.jpg)
 
-Because we won’t be able to access the back of the PCB once we are further along assembly, it is important to install the 3 remaining threaded standoffs to the PCB. These standoffs hold the acrylic cover in place. These standoffs are secured with M2 screws through the back of the PCB using the same method as the backplate.
+Because we won’t be able to access the back of the PCB once we are further along
+assembly, it is important to install the 3 remaining threaded standoffs to the
+PCB. These standoffs hold the acrylic cover in place. These standoffs are
+secured with M2 screws through the back of the PCB using the same method as the
+backplate.
 
 ## Install Switches Into Plate
-![photo of switches in plate](https://boardsource.imgix.net/16363291-0b8c-428d-bae7-0c302a93d2e6.jpg)
+![photo of switches in
+plate](https://boardsource.imgix.net/16363291-0b8c-428d-bae7-0c302a93d2e6.jpg)
 
-Install a MX Compatible switch into each of the switch holes on the plate. Install each switch so that the switch legs run along the lower side and are ‘down.’ Make sure each switch is installed in the same exact direction.
+Install a MX Compatible switch into each of the switch holes on the plate.
+Install each switch so that the switch legs run along the lower side and are
+‘down.’ Make sure each switch is installed in the same exact direction.
 
 ## Sandwich the Plate onto the PCB
 
-![photo of sandiwch](https://boardsource.imgix.net/d5e77905-71f0-4430-8c90-49398021c051.jpg)
+![photo of
+sandiwch](https://boardsource.imgix.net/d5e77905-71f0-4430-8c90-49398021c051.jpg)
 
-In order for final assembly to take place, we must marry the switches, switch plate, and PCB together. The 3x4 Macro Pad utilizes a floating PCB design so it is technically suspended, and the plate is what holds the PCB in place. 
+In order for final assembly to take place, we must marry the switches, switch
+plate, and PCB together. The 3x4 Macro Pad utilizes a floating PCB design so it
+is technically suspended, and the plate is what holds the PCB in place.
 
-Bring the pieces together and line up the switch legs with the holes on the hotswap sockets. Firmly but carefully apply pressure as evenly as possible to press the switch legs into he hotswap sockets. Do small sections at a time and do not press down the entire way, keep doing this around the board until all areas are pressed down entirely. 
+Bring the pieces together and line up the switch legs with the holes on the
+hotswap sockets. Firmly but carefully apply pressure as evenly as possible to
+press the switch legs into he hotswap sockets. Do small sections at a time and
+do not press down the entire way, keep doing this around the board until all
+areas are pressed down entirely.
 
-It is possible to accidentally bend a switch leg, and that is okay, usually you can just remove the plate from the PCB and un-bend the switch leg and then try again. It happens to everyone.
+It is possible to accidentally bend a switch leg, and that is okay, usually you
+can just remove the plate from the PCB and un-bend the switch leg and then try
+again. It happens to everyone.
 
 ## Secure the Plate and PCB to the Backplate
-![photo of attached plate to backplate](https://boardsource.imgix.net/3b51790d-60b6-4c3a-99ff-3ff9088708b0.jpg)
+![photo of attached plate to
+backplate](https://boardsource.imgix.net/3b51790d-60b6-4c3a-99ff-3ff9088708b0.jpg)
 
-Now we can make use of those 4 threaded standoffs we installed on the backplate. Place the plate_PCB assembly into place lining up the holes, and secure the plate_PCB assembly to the backplate’s threaded standoffs using 4 M2 screws through the plate. Do not over tighten.
+Now we can make use of those 4 threaded standoffs we installed on the backplate.
+Place the plate_PCB assembly into place lining up the holes, and secure the
+plate_PCB assembly to the backplate’s threaded standoffs using 4 M2 screws
+through the plate. Do not over tighten.
 
 ## Attach the Acrylic Cover
-![photo of acrylic being attached](https://boardsource.imgix.net/bc7e7ab0-bdb5-44db-b576-ce94eff60c1c.jpg)
+![photo of acrylic being
+attached](https://boardsource.imgix.net/bc7e7ab0-bdb5-44db-b576-ce94eff60c1c.jpg)
 
-Finally, we can install the acrylic cover. The cover attaches to the three threaded standoffs protruding from the top of the PCB. Line up the holes with the standoffs, and loosely secure one at a time. Make sure to leave them slightly loose while you’re lining up the acrylic, then gently tighten each when the acrylic is completely in place. Be sure not to over tighten.
+Finally, we can install the acrylic cover. The cover attaches to the three
+threaded standoffs protruding from the top of the PCB. Line up the holes with
+the standoffs, and loosely secure one at a time. Make sure to leave them
+slightly loose while you’re lining up the acrylic, then gently tighten each when
+the acrylic is completely in place. Be sure not to over tighten.
 
 ## Install Keycaps
 Install any MX Compatible keycap of your choosing onto the switches.
@@ -176,24 +372,7 @@ Install any MX Compatible keycap of your choosing onto the switches.
 
 # All Done!
 
-If you’ve run into issues, come get some help in the Help channel in [our Discord](https://discord.gg/FTun6Cy), or [Submit A Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account section of Boardsource.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+If you’ve run into issues, come get some help in the Help channel in [our
+Discord](https://discord.gg/FTun6Cy), or [Submit A
+Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account
+section of Boardsource.

--- a/build_guides/ETERNAL_Keypad.md
+++ b/build_guides/ETERNAL_Keypad.md
@@ -17,18 +17,18 @@ thumbnail: https://i.imgur.com/u7KRFV9.jpg
 | Item | Count |
 |------|-------|
 | DIODESTYLE Diodes | 36 |
-| PCB | PCBCOUNT |
-| CONTROLLERSTYLE or similar microcontroller | CONTROLLERCOUNT |
-| TRRS Jack | 0 | 
-| TRRS Cable | 0 | 
-| Reset Switch | 1 | 
-| MX Hotswap Sockets | 36 | 
-| MX Switches | 36 | 
+| PCB | 1 |
+| Pro Micro or similar microcontroller | 1 |
+| TRRS Jack | 0 |
+| TRRS Cable | 0 |
+| Reset Switch | 1 |
+| MX Hotswap Sockets | 36 |
+| MX Switches | 36 |
 | *MX* Keycaps | 36 |
 
 ### Optional 
-| Item | Count | 
-|------|-------| 
+| Item | Count |
+|------|-------|
 | SK6812 Mini-E LED | *36* |
 | WS2812B LED | 8 |
 
@@ -37,76 +37,95 @@ thumbnail: https://i.imgur.com/u7KRFV9.jpg
 # Soldering
 ## Diodes
 **Orientation**: Black bar facing downwards or towards the footprint indicator.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/zsCmpM5.jpg)
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/zsCmpM5.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/tXpqRro.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/zic55Px.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/zic55Px.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 ## LEDs
-**Orientation**: Notched corner/pin facing the pad marked with rectangle. This applies for both SK6812 Mini-E & WS2812B LEDs.
-![ws2812b orientation](https://i.imgur.com/guu0UiP_d.jpg?maxwidth=520&shape=thumb&fidelity=high)
-- Notes: \
-\- This component is heat sensitive. Be cautious and work at a safe temp (~300c). \
-\- It is wise to test the LEDs as you solder then. Consider [soldering your controllers beforehand](#microcontrollers). \
-\- The LED order is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order when building.
-1. Solder one pad. (it may be easier to solder all 4 pads before placing LED down when installing WS2812B LEDs)
-![sk6812 mini e one pad](LEDCLOSEUPIMG1)
+**Orientation**: Notched corner/pin facing the pad marked with rectangle. This
+applies for both SK6812 Mini-E & WS2812B LEDs. ![ws2812b
+orientation](https://i.imgur.com/guu0UiP_d.jpg?maxwidth=520&shape=thumb&fidelity=high)
+- Notes: \ \- This component is heat sensitive. Be cautious and work at a safe
+temp (~300c). \ \- It is wise to test the LEDs as you solder then. Consider
+[soldering your controllers beforehand](#microcontrollers). \ \- The LED order
+is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order
+when building.
+1. Solder one pad. (it may be easier to solder all 4 pads before placing LED
+down when installing WS2812B LEDs) ![sk6812 mini e one pad](LEDCLOSEUPIMG1)
 ![ws2812b 4 pads](https://i.imgur.com/StfQVUN.jpg)
 2. While holding LED with tweezers, reflow solder and place LED down on pad.
-![sk6812 mini e placed](LEDCLOSEUPIMG3)
-![ws2812b placed](https://i.imgur.com/bLVeVvu.jpg)
-3. Solder remaining pads.
-![sk6812 mini e complete](https://i.imgur.com/A5ppUFI.jpg)
+![sk6812 mini e placed](LEDCLOSEUPIMG3) ![ws2812b
+placed](https://i.imgur.com/bLVeVvu.jpg)
+3. Solder remaining pads. ![sk6812 mini e
+complete](https://i.imgur.com/A5ppUFI.jpg)
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/Jh7tqQQ.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/RrK1IFS.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/6msPm1l.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/Jh7tqQQ.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/RrK1IFS.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/6msPm1l.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: Both microcontrollers CONTROLLERPLACEMENT.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/uLeKpKX.jpg)
-2. Place microcontroller CONTROLLERPLACEMENT. 
-![microcontroller placed](https://i.imgur.com/kHDmH1w.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/uLeKpKX.jpg)
+2. Place microcontroller CONTROLLERPLACEMENT. ![microcontroller
+placed](https://i.imgur.com/kHDmH1w.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/ehYRVqj.jpg)
 
 ## Misc.
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/sTuoxPH.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/BxkbzxR.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/sTuoxPH.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/BxkbzxR.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under QMKKEYBOARDNAME.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under eternal\_keypad. To begin, follow the
+[QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from
+an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/KLOTZ.md
+++ b/build_guides/KLOTZ.md
@@ -21,137 +21,159 @@ thumbnail: https://boardsource.imgix.net/Misssing
 
 ### REQUIRED PARTS
 
-| Part name         | Count | Remarks | 
+| Part name | Count | Remarks |
 | :---------------- | :---: | :------ |
-| KLOTZ PCB         | 02 | You can find the files for it [here](/PCB/) |
+| KLOTZ PCB | 02 | You can find the files for it [here](/PCB/) |
 | KLOTZ switchplate | 02 | Which you can find [here](/switchplate/) |
-| nice!nano         | 02 | Alternatively, you can use another controller with similar pinout and bluetooth capabilities like the Puchi-BLE |
-| Choc key switch   | 34 | Kailh Choc low profile keyswitches |
-| diodes 1N4148W    | 34 | These are surface mount diodes in SOD123 package |
-| 1u Choc keycaps   | 34 | You can use the black or white keycaps from Kailh, but I recommend MBK keycaps |
-| reset button      | 02 | Through-hole, 2 pin tactile buttons |
-| power switch      | 02 | MSK12C02 |
-| EC12 encoder      | 02 | Technically you could also use EC11 encoder, but flat EC12 like the EC12E2440301 will work best |
-| encoder knob      | 02 | Nearly every encoder knob, which works with the EC12 should work. But if you have acces to a printer you can use [this one](/knob/) |
-| USB cable         | 01 | For connecting the keyboard with your PC |
-| Lipo battery      | 02 | You can use a variety of Lipo batteries, but the cutout in the switchplate is meant to be used with a battery which name ends with 2030, like the 902030.
+| nice!nano | 02 | Alternatively, you can use another controller with similar pinout and bluetooth capabilities like the Puchi-BLE |
+| Choc key switch | 34 | Kailh Choc low profile keyswitches |
+| diodes 1N4148W | 34 | These are surface mount diodes in SOD123 package |
+| 1u Choc keycaps | 34 | You can use the black or white keycaps from Kailh, but I recommend MBK keycaps |
+| reset button | 02 | Through-hole, 2 pin tactile buttons |
+| power switch | 02 | MSK12C02 |
+| EC12 encoder | 02 | Technically you could also use EC11 encoder, but flat EC12 like the EC12E2440301 will work best |
+| encoder knob | 02 | Nearly every encoder knob, which works with the EC12 should work. But if you have acces to a printer you can use [this one](/knob/) |
+| USB cable | 01 | For connecting the keyboard with your PC |
+| Lipo battery | 02 | You can use a variety of Lipo batteries, but the cutout in the switchplate is meant to be used with a battery which name ends with 2030, like the 902030.
 
 ### OPTIONAL PARTS
 
-| Part name              | Count | Remarks | 
+| Part name | Count | Remarks |
 | :--------------------- | :---: | :------ |
-| MCU sockets            | 04 | For socketing your MCU. Highly recommended |
-| MCU pins               | 48 | In combinatin with the MCU sockets |
-| JST Jack               | 02 | JST PH |
-| switch socket          | 34 | Switch sockets for Kailh choc switches |
-| LEDs                   | 06 | 3mm through hole LEDs |
-| resistors              | 06 | R1206 220ohm SMD resistors for the LEDs |
-| screws  				 | 10 | 6mm M2 screws |
-| bolts                  | 10 | M2 bolts |
-| o-rings                | 10 | as optional standoffs. OD4*1.5-150NB |
+| MCU sockets | 04 | For socketing your MCU. Highly recommended |
+| MCU pins | 48 | In combinatin with the MCU sockets |
+| JST Jack | 02 | JST PH |
+| switch socket | 34 | Switch sockets for Kailh choc switches |
+| LEDs | 06 | 3mm through hole LEDs |
+| resistors | 06 | R1206 220ohm SMD resistors for the LEDs |
+| screws | 10 | 6mm M2 screws |
+| bolts | 10 | M2 bolts |
+| o-rings | 10 | as optional standoffs. OD4*1.5-150NB |
 
 
 
 ## INTRODUCTION
 
-Here is an overview of where and on which side each component needs to be soldered (click on the image to see a larger version).
+Here is an overview of where and on which side each component needs to be
+soldered (click on the image to see a larger version).
 
-![KLOTZ solder guide](https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/images/KLOTZ_solderguide.png?raw=true)
+![KLOTZ solder
+guide](https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/images/KLOTZ_solderguide.png?raw=true)
 
-To see what component needs to sit where you can take a look at the [interactive HTML BOM](https://htmlpreview.github.io/?https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/klotz_rev0-2_ibom.html).
+To see what component needs to sit where you can take a look at the [interactive
+HTML
+BOM](https://htmlpreview.github.io/?https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/klotz_rev0-2_ibom.html).
 
-> **Warning**
-> This interactive HTML BOM does show where each component is located, but please still refer to the solder guide above to see if a component needs to go on the top or bottom of the PCB.
+> **Warning** This interactive HTML BOM does show where each component is
+> located, but please still refer to the solder guide above to see if a
+> component needs to go on the top or bottom of the PCB.
 
 ***
 
 ## DIODES
 
-The diodes needs to be soldered on the bottomm of the PCB. Pay attention to their orientation:  They have a small line on one side, which should be on the side the arrow on the PCB is facing to.
+The diodes needs to be soldered on the bottomm of the PCB. Pay attention to
+their orientation: They have a small line on one side, which should be on the
+side the arrow on the PCB is facing to.
 
-<p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
-  <img alt="diode orientation" src="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
-</picture>
-</p>
+<p align="center"> <picture> <source media="(prefers-color-scheme: dark)"
+srcset="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
+<source media="(prefers-color-scheme: light)"
+srcset="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
+<img alt="diode orientation"
+src="https://github.com/GEIGEIGEIST/KLOTZ/raw/main/docs/images/buildguide/diodes_bright.svg?raw=true"/>
+</picture> </p>
 
-Apply a small amount of solder on one pad.\
-Then use tweezers to place the diode on the pads and reheat the solder to secure the diode.
-Now you can solder the second pad.
+Apply a small amount of solder on one pad.\ Then use tweezers to place the diode
+on the pads and reheat the solder to secure the diode. Now you can solder the
+second pad.
 
-![Soldered diode](https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/images/buildguide/diode.jpg?raw=true)
+![Soldered
+diode](https://github.com/GEIGEIGEIST/KLOTZ/blob/main/docs/images/buildguide/diode.jpg?raw=true)
 
 
 ***
 
 ## SWITCH SOCKETS
 
-Here you can apply the same technique as used for the diodes: Apply some solder on one of the pads first.\
-Then place the switch socket in the silk screen markings and reheat the solder. Apply some pressure with a pair of tweezers to make sure the socket is fully seated.\
-Now solder the second pad.
+Here you can apply the same technique as used for the diodes: Apply some solder
+on one of the pads first.\ Then place the switch socket in the silk screen
+markings and reheat the solder. Apply some pressure with a pair of tweezers to
+make sure the socket is fully seated.\ Now solder the second pad.
 
-![switch socket soldered](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/switchsocket.jpg?raw=true)
+![switch socket
+soldered](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/switchsocket.jpg?raw=true)
 
 
 ***
 
 ## POWER SWITCHES
 
-Apply a tiny bit of solder on one of the bigger, outer pads on the bottom of the PCB. The power switch has some tiny knobs on its bottom, which fits into the PCB holes. Hold it in place with tweezers and than reheat the solder on the pad. After this you can solder the other pad and the three pins.
+Apply a tiny bit of solder on one of the bigger, outer pads on the bottom of the
+PCB. The power switch has some tiny knobs on its bottom, which fits into the PCB
+holes. Hold it in place with tweezers and than reheat the solder on the pad.
+After this you can solder the other pad and the three pins.
 
-![power switch](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/power.jpg?raw=true)
+![power
+switch](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/power.jpg?raw=true)
 
 
 ***
 
 ## RESET SWITCHES
 
-Put the legs of the reset switch through the holen on the top of the PCB. 
-You can secure it with some tape, since you need to solder it from below.
+Put the legs of the reset switch through the holen on the top of the PCB. You
+can secure it with some tape, since you need to solder it from below.
 
-![reset switch](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/reset.jpg?raw=true)
+![reset
+switch](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/reset.jpg?raw=true)
 
 ***
 
 ## MICROCONTROLLER
 
-> **Warning**
-> First flash the microcontroller to make sure it works, before soldering it in.
+> **Warning** First flash the microcontroller to make sure it works, before
+> soldering it in.
 
-The microcontroller needs to be mounted on the top, with the components facing downwards (to the PCB).\
-Feel free to use the included header pins, but it's highly recommended to use MillMax low profile sockets.\
-Place the sockets in the marked spots on the bottom side of the PCB.
-You can keep them in place by using masking tape.\
-Then you can flip the board to solder in the sockets from the bottom.
+The microcontroller needs to be mounted on the top, with the components facing
+downwards (to the PCB).\ Feel free to use the included header pins, but it's
+highly recommended to use MillMax low profile sockets.\ Place the sockets in the
+marked spots on the bottom side of the PCB. You can keep them in place by using
+masking tape.\ Then you can flip the board to solder in the sockets from the
+bottom.
 
-![MCU sockets](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/MCU_sockets.jpg?raw=true)
+![MCU
+sockets](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/MCU_sockets.jpg?raw=true)
 
 
 Insert the pins into the sockets.
 
-> **Note**
-> Use tweezers to insert them. Don't apply too much force, you will feel them snap in. After that, you can carefully apply some pressure, using a flat object to make sure they're fully seated. 
+> **Note** Use tweezers to insert them. Don't apply too much force, you will
+> feel them snap in. After that, you can carefully apply some pressure, using a
+> flat object to make sure they're fully seated.
 
-Now place your microcontroller on the pins (components facing the PCB) and solder it to them.\
-You can use flush cutters to trim the header pins.
+Now place your microcontroller on the pins (components facing the PCB) and
+solder it to them.\ You can use flush cutters to trim the header pins.
 
-> **Warning**
-> When trimming with flush cutters wear eye protection or hold your hand close above the pins. Otherwise sharp metal pins flying around might hurt you.
+> **Warning** When trimming with flush cutters wear eye protection or hold your
+> hand close above the pins. Otherwise sharp metal pins flying around might hurt
+> you.
 
-![MCU solder](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/MCU_solder.jpg?raw=true)
+![MCU
+solder](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/MCU_solder.jpg?raw=true)
 
-> **Warning**
-> On this image you can see the charge boost jumper of the nice!nano bridged. This increasesd the max charge rate from 100mA to 500mA. Only do this if your battery is at least 500mAh, to avoid explosions. 
+> **Warning** On this image you can see the charge boost jumper of the nice!nano
+> bridged. This increasesd the max charge rate from 100mA to 500mA. Only do this
+> if your battery is at least 500mAh, to avoid explosions.
 
 
 ***
 
 ## LEDS (optional)
 
-Insert the LEDs from above. It helps to use the switchplate to align them, but you need at least two switches to fixate it.
-This way you can make sure they won't get in the way later.
+Insert the LEDs from above. It helps to use the switchplate to align them, but
+you need at least two switches to fixate it. This way you can make sure they
+won't get in the way later.
 
 ![LEDs](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/LEDs.jpg?raw=true)
 
@@ -160,7 +182,8 @@ This way you can make sure they won't get in the way later.
 
 ## RESITORS (optional)
 
-Than you should remove the plate and solder the tiny resistors next to the LEDs. As you can see here I still haven't a good technique at hand for doing this.
+Than you should remove the plate and solder the tiny resistors next to the LEDs.
+As you can see here I still haven't a good technique at hand for doing this.
 
 ![LEDs](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/resistors.jpg?raw=true)
 
@@ -169,10 +192,12 @@ Than you should remove the plate and solder the tiny resistors next to the LEDs.
 
 ## ENCODERS
 
-> **Note**
-> Currently ZMK only supports encoders on the primary side of split keyboards. 
+> **Note** Currently ZMK only supports encoders on the primary side of split
+> keyboards.
 
-Mount the rotary encoder on the top side of the PCB. It should click into place maybe requiring a firm press. If it's seated correctly solder the pins on the bottom.
+Mount the rotary encoder on the top side of the PCB. It should click into place
+maybe requiring a firm press. If it's seated correctly solder the pins on the
+bottom.
 
 ![encoder](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/encoder.jpg?raw=true)
 
@@ -180,27 +205,34 @@ Mount the rotary encoder on the top side of the PCB. It should click into place 
 
 ## JST (optional)
 
-You don't need to solder a JST jack, but it makes it easier to connect and deconnect your batteries, if they already got a JST plug.
+You don't need to solder a JST jack, but it makes it easier to connect and
+deconnect your batteries, if they already got a JST plug.
 
-![JST jack](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/JST_socket.jpg?raw=true)
+![JST
+jack](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/JST_socket.jpg?raw=true)
 
 
-If you plan to use a JST jack you also need to bridge the jumpers on the top, next to the JST jack.
+If you plan to use a JST jack you also need to bridge the jumpers on the top,
+next to the JST jack.
 
-![JST bridge](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/JST_bridge.jpg?raw=true)
+![JST
+bridge](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/JST_bridge.jpg?raw=true)
 
 
 ***
 
 ## BATTERY 
 
-If you don't use a JST jack you can solder the wires of your battery to these pads. Red to Plus and Black to Minus.\
-In this case you don't need to bridge the jumpers.
+If you don't use a JST jack you can solder the wires of your battery to these
+pads. Red to Plus and Black to Minus.\ In this case you don't need to bridge the
+jumpers.
 
-![JST bridge](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/battery_pads.jpg?raw=true)
+![JST
+bridge](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/battery_pads.jpg?raw=true)
 
 
-You should use double-sided tape (or even double sided foam tape) to attach the battery to the PCB. You can use the switchplae to align it.
+You should use double-sided tape (or even double sided foam tape) to attach the
+battery to the PCB. You can use the switchplae to align it.
 
 ![battery](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/battery.jpg?raw=true)
 
@@ -211,37 +243,49 @@ You should use double-sided tape (or even double sided foam tape) to attach the 
 
 ## CLEANING
 
-This is how your finished PCB probably will look like. You can use an old toothbrush and some isopropanol to clean it from residues. 
+This is how your finished PCB probably will look like. You can use an old
+toothbrush and some isopropanol to clean it from residues.
 
-![Finished PCB](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/PCB_final.jpg?raw=true)
+![Finished
+PCB](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/PCB_final.jpg?raw=true)
 
 
 ***
 
 ## FIRMWARE
 
-If you have not already flashed the firmware to the microcontroller you should do it now, to make sure everything works, before inserting everyting into the case.\
-[Here](https://github.com/GEIGEIGEIST/zmk-config-klotz) you can find the ZMK firmware for the KLOTZ.\
-You need to create an own fork of it. In this fork you can edit the keymap to trigger an Github action, which will create your firmware. 
+If you have not already flashed the firmware to the microcontroller you should
+do it now, to make sure everything works, before inserting everyting into the
+case.\ [Here](https://github.com/GEIGEIGEIST/zmk-config-klotz) you can find the
+ZMK firmware for the KLOTZ.\ You need to create an own fork of it. In this fork
+you can edit the keymap to trigger an Github action, which will create your
+firmware.
 
 
 ***
 
 ## SWITCHPLATE
 
-Since there isn't much space beween switchplate and PCB on choc builds you don't really need screws, but if you use them I recommend O-rings, which are meant to act as spacer between PCB and switchplate. Thick and small ones seem to work best in this case.
+Since there isn't much space beween switchplate and PCB on choc builds you don't
+really need screws, but if you use them I recommend O-rings, which are meant to
+act as spacer between PCB and switchplate. Thick and small ones seem to work
+best in this case.
 
-![O-rings](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/o-rings.jpg?raw=true) 
-
-
-Insert the screws into the holes of the switchplate and use tweezers to secures them with the O-rings.
-
-![switchplate with screws](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/switchplate_screws.jpg?raw=true)
+![O-rings](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/o-rings.jpg?raw=true)
 
 
-Attach the plate to the PCB and use some switches to keep it in place, so you can secure it from the bottom with bolts.
+Insert the screws into the holes of the switchplate and use tweezers to secures
+them with the O-rings.
 
-![plate and PCB](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/plate_case.jpg?raw=true)
+![switchplate with
+screws](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/switchplate_screws.jpg?raw=true)
+
+
+Attach the plate to the PCB and use some switches to keep it in place, so you
+can secure it from the bottom with bolts.
+
+![plate and
+PCB](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/plate_case.jpg?raw=true)
 
 
 ***
@@ -250,14 +294,28 @@ Attach the plate to the PCB and use some switches to keep it in place, so you ca
 
 This is the 3D printed knob you can find [here](/knob/).
 
-![KLOTZ knob](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/knob.jpg?raw=true)
+![KLOTZ
+knob](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/knob.jpg?raw=true)
 
 
 ***
 
 ## FINAL BUILD
 
-Insert the rest of the switches and put some keycaps on.\
-In this picture you see it with Pseudoku CS keycaps on homing keys and thumbs, the other keycaps are MBK blanks.
+Insert the rest of the switches and put some keycaps on.\ In this picture you
+see it with Pseudoku CS keycaps on homing keys and thumbs, the other keycaps are
+MBK blanks.
 
-![KLOR final](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/KLOTZ_final.jpg?raw=true)
+![KLOR
+final](https://github.com/GEIGEIGEIST/KLOTZ/blob/main//docs/images/buildguide/KLOTZ_final.jpg?raw=true)
+
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
+
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/LULU_kit.md
+++ b/build_guides/LULU_kit.md
@@ -13,8 +13,6 @@ banner: https://images.boardsource.xyz/v1_images/16a75fce-87f1-4879-82ad-c8e72a3
 thumbnail: https://images.boardsource.xyz/v1_images/02e4fba4-907c-49c9-a258-5836d44fd519.jpg
 ---
 ### This guide is for *LuLu solderable* PCBs.
-https://i.imgur.com/FOESANU_d.jpg?maxwidth=520&shape=thumb&fidelity=high
-https://i.imgur.com/k9hUQhm_d.jpg?maxwidth=520&shape=thumb&fidelity=high
 # Parts
 ### Required 
 | Item | Count |
@@ -22,109 +20,128 @@ https://i.imgur.com/k9hUQhm_d.jpg?maxwidth=520&shape=thumb&fidelity=high
 | SMD Diodes | 58 |
 | PCB | 2 |
 | Promicro style or similar microcontroller | 1 |
-| TRRS Jack | 2 | 
-| TRRS Cable | 1 | 
-| Reset Switch | 2 | 
-| SOCKETSTYLE Hotswap Sockets | 58 | 
-| SWITCHSTYLE Switches | 58 | 
-| *KEYCAPSTYLE* Keycaps | 58 |
+| TRRS Jack | 2 |
+| TRRS Cable | 1 |
+| Reset Switch | 2 |
+| Choc/MX Hotswap Sockets | 58 |
+| Choc/MX Switches | 58 |
+| Choc/MX Keycaps | 58 |
 
 ### Optional 
-| Item | Count | 
+| Item | Count |
 |------|-------|
-| 128x32 OLED Display | 2 | 
+| 128x32 OLED Display | 2 |
 | SK6812 Mini-E LED | *58* |
 | SK6821-MINI LED | 8 |
-| EC11 Encoder + Knob | 2 |
-![components](https://i.imgur.com/1dlpw9n.jpg)
+| EC11 Encoder + Knob | 2 | ![components](https://i.imgur.com/1dlpw9n.jpg)
 
 # Soldering
 ## Diodes
 **Orientation**: Black bar facing thick wite line on indicator.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/wy7QK95.jpg)
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/wy7QK95.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/9wjvMkg.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/VQrsV67.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/VQrsV67.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 ## LEDs
-**Orientation**: Notched corner/pin facing the pad marked with rectangle. This applies for both SK6812 Mini-E & SK6821-MINI LEDs.
-![sk6812 mini e orientation](https://i.imgur.com/hcw94Po.jpg)
-![SK6821-MINI orientation](https://i.imgur.com/DvV3Rbk.jpg)
-- Notes: \
-\- This component is heat sensitive. Be cautious and work at a safe temp (~300c). \
-\- It is wise to test the LEDs as you solder then. Consider [soldering your controllers beforehand](#microcontrollers). \
-1. Solder one pad. (it may be easier to solder all 4 pads before placing LED down when installing SK6821-MINI LEDs)
-![sk6812 mini e one pad](https://i.imgur.com/Wyp0Hsz.jpg)
-![SK6821-MINI 4 pads](https://i.imgur.com/3GLu3nV.jpg)
+**Orientation**: Notched corner/pin facing the pad marked with rectangle. This
+applies for both SK6812 Mini-E & SK6821-MINI LEDs. ![sk6812 mini e
+orientation](https://i.imgur.com/hcw94Po.jpg) ![SK6821-MINI
+orientation](https://i.imgur.com/DvV3Rbk.jpg)
+- Notes: \ \- This component is heat sensitive. Be cautious and work at a safe
+temp (~300c). \ \- It is wise to test the LEDs as you solder then. Consider
+[soldering your controllers beforehand](#microcontrollers). \
+1. Solder one pad. (it may be easier to solder all 4 pads before placing LED
+down when installing SK6821-MINI LEDs) ![sk6812 mini e one
+pad](https://i.imgur.com/Wyp0Hsz.jpg) ![SK6821-MINI 4
+pads](https://i.imgur.com/3GLu3nV.jpg)
 2. While holding LED with tweezers, reflow solder and place LED down on pad.
-![sk6812 mini e placed](https://i.imgur.com/fhRqqxF.jpg)
-![SK6821-MINI placed](https://i.imgur.com/rnhh1xS.jpg)
-3. Solder remaining pads.
-![sk6812 mini e complete](https://i.imgur.com/MQWEMSW.jpg)
+![sk6812 mini e placed](https://i.imgur.com/fhRqqxF.jpg) ![SK6821-MINI
+placed](https://i.imgur.com/rnhh1xS.jpg)
+3. Solder remaining pads. ![sk6812 mini e
+complete](https://i.imgur.com/MQWEMSW.jpg)
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/2UX7iw9.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/x7VFVli.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/YgssoVO.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/2UX7iw9.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/x7VFVli.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/YgssoVO.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: Both microcontrollers face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/OSXY7sq.jpg)
-2. Place microcontroller face down. 
-![microcontroller placed](https://i.imgur.com/OSXY7sq.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/OSXY7sq.jpg)
+2. Place microcontroller face down. ![microcontroller
+placed](https://i.imgur.com/OSXY7sq.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/TuWKLe0.jpg)
 
 ## OLEDs
-1. Insert headers from front, solder in from the back.
-![Oled placed](https://i.imgur.com/3GM4vPm.jpg)
-2. Solder only one of pins to begin with.
-![oled back one pin soldered](https://i.imgur.com/p1kDtTk.jpg)
+1. Insert headers from front, solder in from the back. ![Oled
+placed](https://i.imgur.com/3GM4vPm.jpg)
+2. Solder only one of pins to begin with. ![oled back one pin
+soldered](https://i.imgur.com/p1kDtTk.jpg)
 3. While reflowing solder joint, position OLED so that it is level & straight.
-4. Solder remaining pins and clip extra length of pins.
-![oled finished](https://i.imgur.com/cmdR9DU.jpg)
+4. Solder remaining pins and clip extra length of pins. ![oled
+finished](https://i.imgur.com/cmdR9DU.jpg)
 
 ## Misc.
 ### TRRS jacks
-1. Position TRRS jack on front of PCB and secure with tape.
-![trrs jack placed](https://i.imgur.com/F2P9kx7.jpg)
-2. Apply solder to all four pins.
-![trrs jack finished](https://i.imgur.com/qJuzYNS.jpg)
+1. Position TRRS jack on front of PCB and secure with tape. ![trrs jack
+placed](https://i.imgur.com/F2P9kx7.jpg)
+2. Apply solder to all four pins. ![trrs jack
+finished](https://i.imgur.com/qJuzYNS.jpg)
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/h3Lfg1h.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/POeAytM.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/h3Lfg1h.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/POeAytM.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under boardsource/lulu/avr.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under boardsource/lulu/avr. To begin, follow
+the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working
+from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under lily58 or boardsource-lulu-blok in Peg
+In Peg or KMK this keyboard can be found under lily58 or boardsource-lulu-blok
+in Peg
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
 
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/Rev34build_guide_.md
+++ b/build_guides/Rev34build_guide_.md
@@ -12,22 +12,22 @@ tags:
 banner: https://i.imgur.com/cXcIuV6.jpg
 thumbnail: https://i.imgur.com/cXcIuV6.jpg
 ---
-### This guide is for *KEYBOARDNAME* PCBs.
+### This guide is for Reviung34 PCBs.
 https://i.imgur.com/GFpmPNH.jpg
 # Parts
 ### Required 
 | Item | Count |
 |------|-------|
 | SMT Diodes | 33-34 |
-| PCB | PCBCOUNT |
+| PCB | 1 |
 | Pro micro stlye or similar microcontroller | Blok |
-| Reset Switch | 1 | 
-| SOCKETSTYLE Hotswap Sockets | 33-34 | 
-| SWITCHSTYLE Switches | 33-34 | 
-| *KEYCAPSTYLE* Keycaps | 33-34 |
+| Reset Switch | 1 |
+| MX Hotswap Sockets | 33-34 |
+| MX Switches | 33-34 |
+| MX Keycaps | 33-34 |
 
 ### Optional 
-| Item | Count | 
+| Item | Count |
 |------|-------|
 | WS2812B LED | 8 |
 
@@ -36,76 +36,92 @@ https://i.imgur.com/GFpmPNH.jpg
 # Soldering
 ## Diodes
 **Orientation**: Black bar facing downwards or towards the footprint indicator.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/l75iEcb.jpg)
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/l75iEcb.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/qWvV8EY.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/kE9cqeO.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/kE9cqeO.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 ## LEDs
-**Orientation**: Notched corner/pin facing the pad marked with rectangle. This applies for both SK6812 Mini-E & WS2812B LEDs.
-![sk6812 mini e orientation](LEDORIENTATIONIMG1)
-![ws2812b orientation](LEDORIENTATIONIMG2)
-- Notes: \
-\- This component is heat sensitive. Be cautious and work at a safe temp (~300c). \
-\- It is wise to test the LEDs as you solder then. Consider [soldering your controllers beforehand](#microcontrollers). \
-\- The LED order is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order when building.
-1. Solder one pad. (it may be easier to solder all 4 pads before placing LED down when installing WS2812B LEDs)
-![sk6812 mini e one pad](LEDCLOSEUPIMG1)
+**Orientation**: Notched corner/pin facing the pad marked with rectangle. This
+applies for both SK6812 Mini-E & WS2812B LEDs. ![sk6812 mini e
+orientation](LEDORIENTATIONIMG1) ![ws2812b orientation](LEDORIENTATIONIMG2)
+- Notes: \ \- This component is heat sensitive. Be cautious and work at a safe
+temp (~300c). \ \- It is wise to test the LEDs as you solder then. Consider
+[soldering your controllers beforehand](#microcontrollers). \ \- The LED order
+is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order
+when building.
+1. Solder one pad. (it may be easier to solder all 4 pads before placing LED
+down when installing WS2812B LEDs) ![sk6812 mini e one pad](LEDCLOSEUPIMG1)
 ![ws2812b 4 pads](https://i.imgur.com/VdBHZeh.jpg)
 2. While holding LED with tweezers, reflow solder and place LED down on pad.
-![sk6812 mini e placed](LEDCLOSEUPIMG3)
-![ws2812b placed](https://i.imgur.com/7nsE6Ud.jpg)
-3. Solder remaining pads.
-![sk6812 mini e complete](LEDCLOSEUPIMG5)
+![sk6812 mini e placed](LEDCLOSEUPIMG3) ![ws2812b
+placed](https://i.imgur.com/7nsE6Ud.jpg)
+3. Solder remaining pads. ![sk6812 mini e complete](LEDCLOSEUPIMG5)
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/Q4Jvemy.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/p6SgExz.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/bFMwdHh.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/Q4Jvemy.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/p6SgExz.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/bFMwdHh.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: Both microcontrollers CONTROLLERPLACEMENT.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/LQE4ido.jpg)
-2. Place microcontroller CONTROLLERPLACEMENT. 
-![microcontroller placed](https://i.imgur.com/7jRClJk.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/LQE4ido.jpg)
+2. Place microcontroller CONTROLLERPLACEMENT. ![microcontroller
+placed](https://i.imgur.com/7jRClJk.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/k9s3qkn.jpg)
 
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/Qm0ER53.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/fWRp5LL.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/Qm0ER53.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/fWRp5LL.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under reviung/reviung34.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under reviung/reviung34. To begin, follow the
+[QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from
+an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
 In Peg or KMK this keyboard can be found under reviung/reviung34
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
-
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/arachno.md
+++ b/build_guides/arachno.md
@@ -21,63 +21,81 @@ https://i.imgur.com/8zi3Gt9.jpg
 | SMD Diodes | 30 |
 | PCB | 1 |
 | Seeed Style or similar microcontroller | 1 |
-| Reset Switch | 0 | 
-| Choc Hotswap Sockets | 30 | 
-| Choc Switches | 30 | 
+| Reset Switch | 0 |
+| Choc Hotswap Sockets | 30 |
+| Choc Switches | 30 |
 | *Choc* Keycaps | 30 |
 
 
-![components](https://i.imgur.com/gsI2ED4.jpg)
-
 # Soldering
 ## Diodes
-**Orientation**: Place the diode with the black bar facing the white closed end of the square.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/B0tFJq5.jpg)
+**Orientation**: Place the diode with the black bar facing the white closed end
+of the square.
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/B0tFJq5.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/nebKz9q.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/MYz765l.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/MYz765l.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/xBaLlFa.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/ZYlgY65.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/YLqHcUj.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/xBaLlFa.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/ZYlgY65.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/YLqHcUj.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: Place controller with compontants facing up.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Solder one pad
-![headers inserted](https://i.imgur.com/6DlAxNB.jpg)
-2. Place microcontroller with componants facing up and reflow the soldered pad to secure the controller. 
-![microcontroller placed](https://i.imgur.com/1tLroev.jpg)
-3. Apply solder to all pins.
-![microcontroller finished](https://i.imgur.com/IsLYdjX.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Solder one pad ![headers inserted](https://i.imgur.com/6DlAxNB.jpg)
+2. Place microcontroller with componants facing up and reflow the soldered pad
+to secure the controller. ![microcontroller
+placed](https://i.imgur.com/1tLroev.jpg)
+3. Apply solder to all pins. ![microcontroller
+finished](https://i.imgur.com/IsLYdjX.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under QMKKEYBOARDNAME.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under arachnophobe. This will require a fork
+of QMK found
+[here](https://github.com/sadekbaroudi/qmk_firmware/tree/master/keyboards/fingerpunch/arachnophobe).
+To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME
+In Peg or KMK this keyboard can be found under arachnophobe. #TODO
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
-
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/architeuthis_dux.md
+++ b/build_guides/architeuthis_dux.md
@@ -19,10 +19,10 @@ thumbnail: https://i.imgur.com/VhvY3Do.png
 |------|-------|
 | PCB | 2 |
 | Promicro-style or similar microcontroller | 2 |
-| TRRS Jack | 2 | 
+| TRRS Jack | 2 |
 | TRRS Cable | 1 |  
-| Choc Hotswap Sockets | 30 | 
-| Choc Switches | 30 | 
+| Choc Hotswap Sockets | 30 |
+| Choc Switches | 30 |
 | *Choc* Keycaps | 30 |
 
 
@@ -31,20 +31,24 @@ thumbnail: https://i.imgur.com/VhvY3Do.png
 # Soldering
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/K9iFUF1.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/6mw1P1j.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/Gu1ZaG4.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/K9iFUF1.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/6mw1P1j.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/Gu1ZaG4.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
-**Orientation**: Both microcontrollers one component face up and one component face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See firmware section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/qiEeM6d.jpg)
-2. Place microcontroller one component face down and one componant face up. 
+**Orientation**: Both microcontrollers one component face up and one component
+face down.
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  firmware section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/qiEeM6d.jpg)
+2. Place microcontroller one component face down and one componant face up.
 ![microcontroller placed](https://i.imgur.com/5ApcPZW.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
@@ -52,28 +56,41 @@ thumbnail: https://i.imgur.com/VhvY3Do.png
 
 ## Misc.
 ### TRRS jacks
-1. Position TRRS jack on front of PCB and secure with tape.
-![trrs jack placed](https://i.imgur.com/hPTzQyx.jpg)
-2. Apply solder to all four pins.
-![trrs jack finished](https://i.imgur.com/hKw5Hjw.jpg)
+1. Position TRRS jack on front of PCB and secure with tape. ![trrs jack
+placed](https://i.imgur.com/hPTzQyx.jpg)
+2. Apply solder to all four pins. ![trrs jack
+finished](https://i.imgur.com/hKw5Hjw.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under a_dux.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under a_dux. To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
 In Peg or KMK this keyboard can be found under a_dux
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
-
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/corne_crkbd.md
+++ b/build_guides/corne_crkbd.md
@@ -17,8 +17,8 @@ thumbnail: https://boardsource.imgix.net/6c04847e-817f-4a92-b982-47b5aec9bfdc.jp
 # Build Guide
 
 
-This is the build guide for Corne Cherry v3.
-[Click here for the Corne Cherry v2 build guide](
+This is the build guide for Corne Cherry v3. [Click here for the Corne Cherry v2
+build guide](
 https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/v2/buildguide_en.md).
 
 ## Parts
@@ -58,29 +58,26 @@ https://github.com/foostan/crkbd/blob/master/corne-cherry/doc/v2/buildguide_en.m
 
 ## Firmware preparation
 
-If you build the firmware yourself, it will take some time to set up the environment,
-so it's best to start at the beginning.\
-It is recommended to flash ProMicro's prior to soldering.\
-For more information,
-please see [firmware](https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md).
+If you build the firmware yourself, it will take some time to set up the
+environment, so it's best to start at the beginning.\ It is recommended to flash
+ProMicro's prior to soldering.\ For more information, please see
+[firmware](https://github.com/foostan/crkbd/blob/master/doc/firmware_en.md).
 
 ## Verification
 
-The PCB for Corne Cherry v3 is as follows.
-Make sure it is the same as your PCB.
+The PCB for Corne Cherry v3 is as follows. Make sure it is the same as your PCB.
 
 ![confirm_front](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/confirm_front.jpg?raw=true)
 
 ![confirm_back](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/confirm_back.jpg?raw=true)
 
-The PCB comes with a frame for manufacturing reasons.
-You can fold it by hand to remove it, but if it is difficult,
-make a cut in the joint\* with a cutter or similar,
-to make it easier to remove.
-In addition, the joint can be cleaned with a file.
+The PCB comes with a frame for manufacturing reasons. You can fold it by hand to
+remove it, but if it is difficult, make a cut in the joint\* with a cutter or
+similar, to make it easier to remove. In addition, the joint can be cleaned with
+a file.
 
-\**Joint part: There are a total of 8 parts,
-which are marked in red in the image below.*
+\**Joint part: There are a total of 8 parts, which are marked in red in the
+image below.*
 
 ![confirm_remove_frame](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/confirm_remove_frame.jpg?raw=true)
 
@@ -88,47 +85,44 @@ which are marked in red in the image below.*
 
 ### Diodes
 
-Since SMD parts are very small, fine-tip/reverse-action tweezers are recommended.
+Since SMD parts are very small, fine-tip/reverse-action tweezers are
+recommended.
 
-**The diodes have a specific orientation**, so install with "|" marking on the diode
-facing the "|" on the PCB marking: "|◁"
+**The diodes have a specific orientation**, so install with "|" marking on the
+diode facing the "|" on the PCB marking: "|◁"
 
 ![build_diode](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_diode.jpg?raw=true)
 
-<details>
-<summary>TIPS: Tips for installing SMD parts</summary>
+<details> <summary>TIPS: Tips for installing SMD parts</summary>
 
 Begin with applying solder to only one pad.
 
 ![tips_building_smd_01](https://user-images.githubusercontent.com/736191/54487435-79330280-48d9-11e9-9138-525d8ee68144.jpg?raw=true)
 
-Next, place SMD component while heating solder. At this time,
-it is recommended to use [reverse-action tweezers](https://www.alimed.com/_resources/cache/images/product/70895A_850x480-pad.jpg),
-so that you can hold the SMD part firmly without applying force,
-and concentrate on alignment and soldering instead.
-Also, if the soldering iron is too hot or the solder is touched too long,
-the flux contained in the solder may evaporate and form a poor solder joint,
-but it can be repaired later,
-so at this point you should only care about attaching parts.
-It's okay.
+Next, place SMD component while heating solder. At this time, it is recommended
+to use [reverse-action
+tweezers](https://www.alimed.com/_resources/cache/images/product/70895A_850x480-pad.jpg),
+so that you can hold the SMD part firmly without applying force, and concentrate
+on alignment and soldering instead. Also, if the soldering iron is too hot or
+the solder is touched too long, the flux contained in the solder may evaporate
+and form a poor solder joint, but it can be repaired later, so at this point you
+should only care about attaching parts. It's okay.
 
 ![tips_building_smd_02](https://user-images.githubusercontent.com/736191/54487436-79330280-48d9-11e9-856e-f3f5b9f58414.jpg)
 
-It is okay if the SMD component is not flush with the PCB when viewed from the side.
-If it is floating, press the SMD component down with tweezers or your finger and reheat the solder.
+It is okay if the SMD component is not flush with the PCB when viewed from the
+side. If it is floating, press the SMD component down with tweezers or your
+finger and reheat the solder.
 
 ![tips_building_smd_03](https://user-images.githubusercontent.com/736191/54487437-79330280-48d9-11e9-996d-a578e767c12c.jpg)
 
-Then solder the other contacts.
-Be careful not to apply too much solder,
-as a small amount is sufficient.
-If you have applied too much,
-you can remove it with a suction pump, solder wick,
-or by picking it up with a soldering iron.
+Then solder the other contacts. Be careful not to apply too much solder, as a
+small amount is sufficient. If you have applied too much, you can remove it with
+a suction pump, solder wick, or by picking it up with a soldering iron.
 
-If the amount of solder on the preliminary solder side is small,
-additional soldering is performed, and if it is a heap,
-apply flux from above and heat it to clean it.
+If the amount of solder on the preliminary solder side is small, additional
+soldering is performed, and if it is a heap, apply flux from above and heat it
+to clean it.
 
 ![tips_building_smd_04](https://user-images.githubusercontent.com/736191/54487438-79cb9900-48d9-11e9-9280-dc72a2087307.jpg)
 
@@ -145,7 +139,8 @@ Solder the SK6812MINI-E and WS2812B.
 ![build_led_front_overview](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_led_front_overview.jpg?raw=true)
 
 All soldering is done from the back side, but the SK6812MINI-E is for Backlight
-(the front side is shining) and the WS2812B is for Undergrow (the back side is shining).
+(the front side is shining) and the WS2812B is for Undergrow (the back side is
+shining).
 
 ![build_led_back_overview](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_led_back_overview.jpg?raw=true)
 
@@ -154,8 +149,8 @@ All soldering is done from the back side, but the SK6812MINI-E is for Backlight
 First, solder the WS2812B.
 
 Match recessed corner of the LED with marked corner on the PCB as shown below.
-Refer to **TIPS: Tips for installing SMD parts** section above as similar soldering
-procedure is followed. 
+Refer to **TIPS: Tips for installing SMD parts** section above as similar
+soldering procedure is followed.
 
 ![build_led_undergrow](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_led_undergrow.jpg?raw=true)
 
@@ -167,38 +162,41 @@ WS2812B LED soldering is completed after 12 are installed on left and right.
 
 Then solder the SK6812MINI-E.
 
-Match the notched corner of the LED with the marked corner on the PCB as show below.
-Refer to **TIPS: Tips for installing SMD parts** section above as similar soldering
-procedure is followed. 
-These are more resilient than the SK6812MINI LEDs,
-but still may be damaged if directly exposed to the heat of a soldering iron.
-~320°C seems to be an ok temperature, evne if all four legs are soldered 
+Match the notched corner of the LED with the marked corner on the PCB as show
+below. Refer to **TIPS: Tips for installing SMD parts** section above as similar
+soldering procedure is followed. These are more resilient than the SK6812MINI
+LEDs, but still may be damaged if directly exposed to the heat of a soldering
+iron. ~320°C seems to be an ok temperature, evne if all four legs are soldered
 one after another.
 
 ![build_led_backlight](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_led_backlight.jpg?raw=true)
 
-SK6812MINI-E LED soldering is completed after 42 are installed on left and right.
+SK6812MINI-E LED soldering is completed after 42 are installed on left and
+right.
 
 ![build_led_back_overview](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_led_back_overview.jpg?raw=true)
 
 ### TRRS jack, reset switch, pin socket for OLED
 
-Solder the TRRS jack, reset switch (tact switch),
-and OLED pin socket as shown in the picture below.
+Solder the TRRS jack, reset switch (tact switch), and OLED pin socket as shown
+in the picture below.
 
 ![build_trrs_reset_oled](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_trrs_reset_oled.jpg?raw=true)
 
-Since these parts may fall off when soldering, you can affix them with masking tape.
+Since these parts may fall off when soldering, you can affix them with masking
+tape.
 
 ### ProMicro
 
-Solder headers to PCB. Then solder ProMicro to headers, with components facing PCB as shown below.
+Solder headers to PCB. Then solder ProMicro to headers, with components facing
+PCB as shown below.
 
 ![build_promicro](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_promicro.jpg?raw=true)
 
-If you use [spring-loaded pin headers](https://shop.yushakobo.jp/collections/all-keyboard-parts/products/31),
-you do not need to solder the back side.
-Please refer to the [Helix Build Guide](
+If you use [spring-loaded pin
+headers](https://shop.yushakobo.jp/collections/all-keyboard-parts/products/31),
+you do not need to solder the back side. Please refer to the [Helix Build
+Guide](
 https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_en.md#pro-micro)
 for details on how to use spring-loaded pin headers.
 
@@ -206,10 +204,9 @@ for details on how to use spring-loaded pin headers.
 
 ### OLED module
 
-Insert the pin header into the socket first, then solder the OLED module
-to the pin header.
-Note: Solder one pin to OLED module, then reheat solder to confirm OLED module is level,
-then solder remaining pins.
+Insert the pin header into the socket first, then solder the OLED module to the
+pin header. Note: Solder one pin to OLED module, then reheat solder to confirm
+OLED module is level, then solder remaining pins.
 
 ![build_oled](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_oled.jpg?raw=true)
 
@@ -217,16 +214,16 @@ then solder remaining pins.
 
 Now is a good time to test your keyboard to help isolate potential problems.
 
-To check the operation, connect left and right sides with TRRS cable,
-then connect left side to the computer with USB cable.
-If it is done correctly so far, shorting a hotswap socket pad with tweezers will 
-output out a keypress and it will be displayed on the OLED module.
+To check the operation, connect left and right sides with TRRS cable, then
+connect left side to the computer with USB cable. If it is done correctly so
+far, shorting a hotswap socket pad with tweezers will output out a keypress and
+it will be displayed on the OLED module.
 
 ### Switch Sockets
 
-Solder hotswap sockets according to mark on PCB as shown below.
-Refer to **TIPS: Tips for installing SMD parts** section above as similar soldering
-procedure is followed. 
+Solder hotswap sockets according to mark on PCB as shown below. Refer to **TIPS:
+Tips for installing SMD parts** section above as similar soldering procedure is
+followed.
 
 ![build_socket](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_socket.jpg?raw=true)
 
@@ -243,10 +240,10 @@ Attach the OLED protective cover with M2 9mm spacers and M2 screws.
 
 ### Plates & Switches
 
-Place a few key switches into the top plate, then line up and press into PCB socket.
-If you attach all the key switches to the top plate first,
-it will be more difficult to fit them in the PCB sockets all at once.
-So it is recommended to do a few to begin with. 
+Place a few key switches into the top plate, then line up and press into PCB
+socket. If you attach all the key switches to the top plate first, it will be
+more difficult to fit them in the PCB sockets all at once. So it is recommended
+to do a few to begin with.
 
 ![build_top_plate_switches](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_top_plate_switches.jpg?raw=true)
 
@@ -254,7 +251,8 @@ Install the M2 7.5mm spacer and M2 screws on the top plate.
 
 ![build_screws_spacers_front](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_screws_spacers_front.jpg?raw=true)
 
-It is easy to screw the spacer in after inserting it into the hole from the back side.
+It is easy to screw the spacer in after inserting it into the hole from the back
+side.
 
 ![build_screws_spacers_back](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_screws_spacers_back.jpg?raw=true)
 
@@ -269,3 +267,35 @@ Install the rubber feet in the following positions.
 That's it!
 
 ![build_finish](https://github.com/foostan/crkbd/blob/main/corne-cherry/doc/v3/assets/build_finish.jpg?raw=true)
+
+## Firmware
+
+### QMK
+In qmk this keyboard can be found under a_dux. To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under a_dux
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
+
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/draculad.md
+++ b/build_guides/draculad.md
@@ -22,129 +22,125 @@ thumbnail: https://images.boardsource.xyz/v1_images/02e4fba4-907c-49c9-a258-5836
 - 38x sod123 SMD diodes
 - 2x reset switches
 - 2x TRRS jacks
-- 8x 0.7cm standoffs, 16 m2 screws to mount the case 
+- 8x 0.7cm standoffs, 16 m2 screws to mount the case
 - usb cable, trrs cable, rotary encoder knobs, keycaps
 
 ## What you optionally need
-- 2x extra rotary encoders (for the thumb cluster, each additional rotary encoder decreases the needed switchcount by one)
+- 2x extra rotary encoders (for the thumb cluster, each additional rotary
+  encoder decreases the needed switchcount by one)
 - 20x ws2812b LEDs (if you want underglow)
 - 2x SSD1306 OLEDs (128x64)
 - 2x OLED cover
-- 6x standoffs with m2 screws for the OLED cover (standoff size depends on whether you use the OLEDs or not and probably also how low profile your pro micro is mounted (bit-c for example is a bit higher profile), with OLEDs 1cm is ok)
-- 1x pimoroni trackball (this will only fit for the plateless build or the one with the FR4 plate)
+- 6x standoffs with m2 screws for the OLED cover (standoff size depends on
+  whether you use the OLEDs or not and probably also how low profile your pro
+  micro is mounted (bit-c for example is a bit higher profile), with OLEDs 1cm
+  is ok)
+- 1x pimoroni trackball (this will only fit for the plateless build or the one
+  with the FR4 plate)
 
 ## First step: solder the Diodes
 - the diode mark should be aligned with the mark on the PCB
-- solder the diodes on the bottom of the PCB, the PCBs are reversible, therefore you need to decide for one side in the beginning 
-- put solder on one of the pads, reflow the solder while sliding the diode into place, solder the second side of the diode
+- solder the diodes on the bottom of the PCB, the PCBs are reversible, therefore
+  you need to decide for one side in the beginning
+- put solder on one of the pads, reflow the solder while sliding the diode into
+  place, solder the second side of the diode
 
 ## Second step: solder the LEDs
 - the little triangle on the LED should allign with the triangle on the PCB
-- do it similar to the diode, first solder one pad, slide in the LED, solder the other 3 joints
-- be careful, those things are really heat sensitive, only ever touch the metal part with the iron, never the plastic - if possible, don't touch the LED with the iron but let the solder flow onto the joints
+- do it similar to the diode, first solder one pad, slide in the LED, solder the
+  other 3 joints
+- be careful, those things are really heat sensitive, only ever touch the metal
+  part with the iron, never the plastic - if possible, don't touch the LED with
+  the iron but let the solder flow onto the joints
 
 ## Third step: install the pro micros
-- before installing the pro micro, flash it with the right firmware which can be found on the [qmk master](https://github.com/qmk/qmk_firmware) or, if you're using a bluetooth controller like the Nice!Nano or the nRFMicro, refer to my fork of the zmk firmware which should implement some basic features on the "draculad"-branch.
+- before installing the pro micro, flash it with the right firmware which can be
+  found on the [qmk master](https://github.com/qmk/qmk_firmware) or, if you're
+  using a bluetooth controller like the Nice!Nano or the nRFMicro, refer to my
+  fork of the zmk firmware which should implement some basic features on the
+  "draculad"-branch.
 - the pro micro headers/sockets should be in the outlines marked on the PCB
-- if you need help socketing your controller or never did it before, refer to [this section of the crkbd buildguide](https://nicedoc.io/foostan/crkbd/blob/master/corne-classic/doc/buildguide_en.md#use-socket-to-mount-promicro)
-- I strongly recommend socketing your pro micros or pro micro clone
-- for reference on how to install your pro micro please look at the [crkbd buildguide](https://nicedoc.io/foostan/crkbd/blob/master/corne-classic/doc/buildguide_en.md). 
-- now is the right time to plug in your keyboard and check whether everything works - if you did everything right, every switch - besides the ones that switch layers (refer to the layout in the firmware) - should give you a feedback and all the LEDs should light up red. The LEDs are daisy chained, so check them by correcting them one by one in the chain that starts at the bottom of the pro micro and follows all around on the edge of the PCB
+- now is the right time to plug in your keyboard and check whether everything
+  works - if you did everything right, every switch - besides the ones that
+  switch layers (refer to the layout in the firmware) - should give you a
+  feedback and all the LEDs should light up red. The LEDs are daisy chained, so
+  check them by correcting them one by one in the chain that starts at the
+  bottom of the pro micro and follows all around on the edge of the PCB
 
 ## Fourth step: Install your Pimoroni, OLEDs, Encoders
-- for the OLEDs, jump the OLED jumpers on top of the PCB and solder in the OLEDs. Add some insulating tape on the bottom of the OLED to avoid shorts with the pro micro, after that just solder them in, there's not much you can do wrong here
-![OLED with insulation tape on bottom](https://github.com/MangoIV/dracuLad/blob/master/pictures/rev2/OLED_insulated.jpeg?raw=true)
+- for the OLEDs, jump the OLED jumpers on top of the PCB and solder in the
+OLEDs. Add some insulating tape on the bottom of the OLED to avoid shorts with
+the pro micro, after that just solder them in, there's not much you can do wrong
+here ![OLED with insulation tape on
+bottom](https://github.com/MangoIV/dracuLad/blob/master/pictures/rev2/OLED_insulated.jpeg?raw=true)
 
 - test them by pluggin in, they should both come on
-- for the pimoronis you should not compile the default keymap but rather the "pimoroni" one 
+- for the pimoronis you should not compile the default keymap but rather the
+  "pimoroni" one
 - jump the pimoroni jumpers on top of the PCB
-- before soldering the pimoroni, make sure you insulate it with a bit of insulation tape
-- solder the pimoroni in
+- before soldering the pimoroni, make sure you insulate it with a bit of
+  insulation tape
+- solder the pimoroni in if applicable
 - the pins should be as flush as possible with the top of the pimoroni pcb
 - the pimoroni pcb should be parallel to the draculad pcb
-- to optimise the profile, use diode pins to connect the pimoroni to the pcb
-- after plugging in, your trackball should light up red and work now 
-- clip away the short, thick legs of the encoder (!NOT THE PINS!) and solder them into the spots you want them
+- to optimize the profile, use diode pins to connect the pimoroni to the pcb
+- after plugging in, your trackball should light up red and work now
+- clip away the short, thick legs of the encoder (!NOT THE PINS!) and solder
+  them into the spots you want them
 - remember, all 4 encoder spots are supported at once
 
 ## Fifth step: Take a break
-At this point you should have a fully working keyboard barebone. Test the encoders and whether there are any errors plugging in the keyboard. Both OLEDs should work, as well as the LEDs and the Pimoroni.
-If not, try to correct your mistakes, don't lose your temper, most of the things can be corrected very easily.
-If you're debugging your keyboard under Linux, you can test the keys and the encoders by using ```xev -event keyboard``` and whether the keyboard is correctly recognised with ```dmesg --follow -H```. (Mind that you need proper rights to run this command.) 
+At this point you should have a fully working keyboard barebone. Test the
+encoders and whether there are any errors plugging in the keyboard. Both OLEDs
+should work, as well as the LEDs and the Pimoroni. If not, try to correct your
+mistakes, don't lose your temper, most of the things can be corrected very
+easily. If you're debugging your keyboard under Linux, you can test the keys and
+the encoders by using ```xev -event keyboard``` and whether the keyboard is
+correctly recognized with ```dmesg --follow -H```. (Mind that you need proper
+rights to run this command.)
 
-In the improbable case you're using nix, you can get the keyboard tester with 
+In the improbable case you're using nix, you can get the keyboard tester with
 
 ```nix
 nix-shell -p "xorg.xev" --run "xev -event keyboard"
 ``` 
 
 ## Sixth step, solder in the switches
-- depending on whether you build it with or without plate, stick the switches through the plate and then through the pin holes. Solder the pins. 
+- depending on whether you build it with or without plate, stick the switches
+  through the plate and then through the pin holes. Solder the pins.
 - mount the OLED cover, use the longer standoffs for that
 - screw the shorter standoffs to the switch plate and then to the bottom plate
 - mount keycaps
-- have fun tinkering with qmk (or zmk)
+
+## Firmware
+
+### QMK
+In qmk this keyboard can be found under draculad To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under draculad
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
 
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
-
-# *title*
-## sub title
-### sub sub title
-#### sub sub sub title
-normal text 
-
-**bold text**
-
-*italic text*
-
-~~strikethrough text~~
-
-> blockquote
-
-* bullet list
-- bullet list
-
-1. # numbered list
-2. numbered list
-
-- [x] task list
-- [ ] task list
-
-
-[home](https//:how.com)
-```
-code block
-```
-
-`inline code`
-
-[link](https://www.google.com)
-
-
-![image](https://github.com/adam-)
-
-
-## parrts
-
-* pcb
-    - 2 pcbs
-    - 2 controllers
-* case
-
-ta da!
-
-## table
-
-| header1 | header2 |
-| --- | --- |
-| cell1 | cell2 |
-| cell3 | cell4 |
-
-## task list
-
-- [x] task 1
-- [ ] task 2
-
-
-
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/equals.md
+++ b/build_guides/equals.md
@@ -25,35 +25,53 @@ thumbnail: https://images.boardsource.xyz/eq-1-1.jpg
 |------|-------|
 | Equals Case | 1 |
 | Equals PCB | 1 |
-| Switches | 48 or 60 | 
+| Switches | 48 or 60 |
 | Keycaps | 48 or 60 |
 
 ### Optional 
-| Item | Count | 
-|------|-------| 
+| Item | Count |
+|------|-------|
 | 2u Stabilizer | 1 |
 | 2u Keycap | 1 |
 
-This build guide is designed to work seamlessly with all Equals keyboard kits, offering compatibility with both MX and Choc switches, as well as the choice between 48 or 60 layouts. Notably, when assembling an Equals 60 keyboard, there is no requirement to snap off the PCB, simplifying the process. Furthermore, for Choc builds, the PCB eliminates the need for a stabilizer, further streamlining the assembly. This user-friendly guide ensures a smooth and hassle-free experience across different Equals keyboard variations, accommodating diverse preferences and needs with clarity and precision.
+This build guide is designed to work seamlessly with all Equals keyboard kits,
+offering compatibility with both MX and Choc switches, as well as the choice
+between 48 or 60 layouts. Notably, when assembling an Equals 60 keyboard, there
+is no requirement to snap off the PCB, simplifying the process. Furthermore, for
+Choc builds, the PCB eliminates the need for a stabilizer, further streamlining
+the assembly. This user-friendly guide ensures a smooth and hassle-free
+experience across different Equals keyboard variations, accommodating diverse
+preferences and needs with clarity and precision.
 
 ![components](https://images.boardsource.xyz/eq-2.jpg)
 # Step 1 The Break!
 ## **Important READ!**
 
-If you're assembling an Equals 60 keyboard, you can skip Step 1 in the guide, which involves snapping off the PCB. It's essential to highlight that once the PCB is snapped, it's a permanent change. However, this step is unique to the Equals 48 / 4x12 layout and doesn't apply to the Equals 60 / 5x12 layout. This adjustment simplifies the assembly process and maintains the keyboard's integrity by avoiding irreversible modifications.
+If you're assembling an Equals 60 keyboard, you can skip Step 1 in the guide,
+which involves snapping off the PCB. It's essential to highlight that once the
+PCB is snapped, it's a permanent change. However, this step is unique to the
+Equals 48 / 4x12 layout and doesn't apply to the Equals 60 / 5x12 layout. This
+adjustment simplifies the assembly process and maintains the keyboard's
+integrity by avoiding irreversible modifications.
 
 ## For Equals 48 / 4x12
-Hold the PCB and slowly bend the bottom row until you here it snap, working up and down the length of the keyboard.
+Hold the PCB and slowly bend the bottom row until you here it snap, working up
+and down the length of the keyboard.
 
-**Note on Technik Case:**
-For builds in a Technik case Depending on how the snap goes you may need to trim / sand the Broken ends for the PCB to fit in the case.
+**Note on Technik Case:** For builds in a Technik case Depending on how the snap
+goes you may need to trim / sand the Broken ends for the PCB to fit in the case.
 
-![Breaking pcb video](https://images.boardsource.xyz/eq-g-1.gif)
-![Broken PCB](https://images.boardsource.xyz/eq-3.jpg)
+![Breaking pcb video](https://images.boardsource.xyz/eq-g-1.gif) ![Broken
+PCB](https://images.boardsource.xyz/eq-3.jpg)
 
 # Step 2 Line it up.
 
-Aligning the plate, plate foam, and PCB is a straightforward process, as they are designed to fit together in only one specific orientation. Ensuring proper alignment is crucial for optimal performance and stability. Just take your time to make sure the missing intersections in the late foam line up with the post holes on the PCB and the screw holes in the plate line up with the same post holes.
+Aligning the plate, plate foam, and PCB is a straightforward process, as they
+are designed to fit together in only one specific orientation. Ensuring proper
+alignment is crucial for optimal performance and stability. Just take your time
+to make sure the missing intersections in the late foam line up with the post
+holes on the PCB and the screw holes in the plate line up with the same post
+holes.
 
 You should be left with a stack that sits:
 
@@ -61,20 +79,23 @@ You should be left with a stack that sits:
 * **Foam**
 * **PCB**
 
-**Note on Choc Builds:**
-Due to the shorter height there is not enough space between the plate and the PCB for foam so no foam is required(or included).
+**Note on Choc Builds:** Due to the shorter height there is not enough space
+between the plate and the PCB for foam so no foam is required(or included).
 
 ![Video of lining up the parts.](https://images.boardsource.xyz/eq-g-2.gif)
 
 # Step 3 Put the Switches in!
-Now  that all the holes line up you can insert your switches.
-Make sure that you line up the metal pins on the switch with the hotswap on the PCB each switch can only go in one way to work.
-When inserting your switch support the back of the hotswap to insure you dont break the PCB while installing switches (which can happen if the switch is miss aligned.)
+Now that all the holes line up you can insert your switches. Make sure that you
+line up the metal pins on the switch with the hotswap on the PCB each switch can
+only go in one way to work. When inserting your switch support the back of the
+hotswap to insure you dont break the PCB while installing switches (which can
+happen if the switch is miss aligned.)
 
 ![components](https://images.boardsource.xyz/eq-g-3.gif)
 ![components](https://images.boardsource.xyz/eq-4.jpg)
 
-Now you can test your PCB to make sure every switch works if not pop out the switch that does not work and check for bent pins.
+Now you can test your PCB to make sure every switch works if not pop out the
+switch that does not work and check for bent pins.
 # Step 4 Getting so Close.
 Drop your PCB / Plate / Switch assembly into the case.
 
@@ -91,18 +112,18 @@ Throw your favorite keycap set on and enjoy your new ortho keyboard.
 ![components](https://images.boardsource.xyz/eq-g-6.gif)
 ![components](https://images.boardsource.xyz/eq-6.jpg)
 
-Thank you for buying a Equals keyboard from Boardsource we really hope you enjoy it.
+Thank you for buying a Equals keyboard from Boardsource we really hope you enjoy
+it.
 
-Here are some links to other articles that may help you  get the  most out of your new keyboard:
-* Learn more about your PCB [Guide to the new Equals PCB](https://new.boardsource.xyz/docs/guides-equals_pcb)
-* Get the most out of your PCB [Unleashing the High-Tech Power of Custom Keyboards](https://new.boardsource.xyz/docs/articles-features)
-* [Keyboard Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Learn more about your PCB [Guide to the new Equals
+  PCB](https://new.boardsource.xyz/docs/guides-equals_pcb)
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
-
-
-
-
-
-
-
-
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/equals_kit.md
+++ b/build_guides/equals_kit.md
@@ -20,65 +20,71 @@ thumbnail: https://i.imgur.com/uPUZxvA.png
 | SMD Diodes | 60 |
 | PCB | 1 |
 | Promicro style or similar microcontroller | 1 |
-| Reset Switch | 1 | 
-| SOCKETSTYLE Hotswap Sockets | 60 | 
-| SWITCHSTYLE Switches | 60 | 
+| Reset Switch | 1 |
+| SOCKETSTYLE Hotswap Sockets | 60 |
+| SWITCHSTYLE Switches | 60 |
 | *KEYCAPSTYLE* Keycaps | 60 |
 
 ### Optional 
-| Item | Count | 
+| Item | Count |
 |------|-------|
 | SK6812 Mini-E LED | *60* |
-| WS2812B LED | 10 |
-![components](https://i.imgur.com/8h2rClk.jpg)
+| WS2812B LED | 10 | ![components](https://i.imgur.com/8h2rClk.jpg)
 
 # Soldering
 ## Diodes
-**Orientation**: Place the diode on the pcb with the black bar facing the thick white line on the pcb.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/ARJgn51.jpg)
+**Orientation**: Place the diode on the pcb with the black bar facing the thick
+white line on the pcb.
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/ARJgn51.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/ycIxaYC.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/L9Bw86b.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/L9Bw86b.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 ## LEDs
-**Orientation**: Notched corner/pin facing the pad marked with rectangle. This applies for both SK6812 Mini-E & WS2812B LEDs.
-![sk6812 mini e orientation](https://i.imgur.com/hcw94Po_d.jpg?maxwidth=520&shape=thumb&fidelity=high)
+**Orientation**: Notched corner/pin facing the pad marked with rectangle. This
+applies for both SK6812 Mini-E & WS2812B LEDs. ![sk6812 mini e
+orientation](https://i.imgur.com/hcw94Po_d.jpg?maxwidth=520&shape=thumb&fidelity=high)
 ![ws2812b orientation](https://i.imgur.com/guu0UiP.jpgx)
-- Notes: \
-\- This component is heat sensitive. Be cautious and work at a safe temp (~300c). \
-\- It is wise to test the LEDs as you solder then. Consider [soldering your controllers beforehand](#microcontrollers). \
-\- The LED order is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order when building.
-1. Solder one pad. (it may be easier to solder all 4 pads before placing LED down when installing WS2812B LEDs)
-![sk6812 mini e one pad](https://i.imgur.com/CzNgJjl.jpg)
-![ws2812b 4 pads](https://i.imgur.com/HNruR0N.jpg)
+- Notes: \ \- This component is heat sensitive. Be cautious and work at a safe
+temp (~300c). \ \- It is wise to test the LEDs as you solder then. Consider
+[soldering your controllers beforehand](#microcontrollers). \ \- The LED order
+is somewhat outlined ![LED order](LEDORDERIMG) and should be followed in order
+when building.
+1. Solder one pad. (it may be easier to solder all 4 pads before placing LED
+down when installing WS2812B LEDs) ![sk6812 mini e one
+pad](https://i.imgur.com/CzNgJjl.jpg) ![ws2812b 4
+pads](https://i.imgur.com/HNruR0N.jpg)
 2. While holding LED with tweezers, reflow solder and place LED down on pad.
-![sk6812 mini e placed](https://i.imgur.com/10rMG0j.jpg)
-![ws2812b placed](https://i.imgur.com/v1z97ud.jpg)
-3. Solder remaining pads.
-![sk6812 mini e complete](https://i.imgur.com/cfytqak.jpg,https://i.imgur.com/SGx5Rxe.jpg)
+![sk6812 mini e placed](https://i.imgur.com/10rMG0j.jpg) ![ws2812b
+placed](https://i.imgur.com/v1z97ud.jpg)
+3. Solder remaining pads. ![sk6812 mini e
+complete](https://i.imgur.com/cfytqak.jpg,https://i.imgur.com/SGx5Rxe.jpg)
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/TvVu7mr.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/kVzCyZM.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/NIIgjbi.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
-- Oreantation of middle cluster of hot swaps 
-![hot swap oreantation](https://i.imgur.com/zOeROG9.jpg)
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/TvVu7mr.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/kVzCyZM.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/NIIgjbi.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
+- Oreantation of middle cluster of hot swaps ![hot swap
+oreantation](https://i.imgur.com/zOeROG9.jpg)
 
 ## Microcontrollers
 **Orientation**: Place controller with the companants faceing down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/0LIcQwb.jpg)
-2. Place microcontroller face down. 
-![microcontroller placed](https://i.imgur.com/Z80g7oY.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/0LIcQwb.jpg)
+2. Place microcontroller face down. ![microcontroller
+placed](https://i.imgur.com/Z80g7oY.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/BZrXPIU.jpg)
@@ -86,29 +92,45 @@ you may need to reflow and add more solder a couple times before an adequate con
 
 ## Misc
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/wI6NdQN.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/pBkpjSF.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/wI6NdQN.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/pBkpjSF.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under boardsource/equals/48/avr  or boardsource/equals/60/avr.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under boardsource/equals/48/avr or
+boardsource/equals/60/avr. To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under boardsource/equals48-kit or boardsource/equals60-kit
+In Peg or KMK this keyboard can be found under boardsource/equals48-kit or
+boardsource/equals60-kit
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/humla.md
+++ b/build_guides/humla.md
@@ -14,7 +14,6 @@ thumbnail: https://i.imgur.com/Gsbvhhi.png
 ---
 
 ### This guide is for *Humla* PCBs.
-https://imgur.com/a/7rE2mbz
 # Parts
 ### Required 
 | Item | Count |
@@ -22,9 +21,9 @@ https://imgur.com/a/7rE2mbz
 | Smd Diodes | 36 |
 | PCB | 1 |
 | Pro-Micro or similar microcontroller | 1 |
-| Reset Switch | 1 | 
-| Choc Hotswap Sockets | 36 | 
-| Choc Switches | 36 | 
+| Reset Switch | 1 |
+| Choc Hotswap Sockets | 36 |
+| Choc Switches | 36 |
 | Choc Keycaps | 36 |
 
 
@@ -33,34 +32,37 @@ https://imgur.com/a/7rE2mbz
 
 # Soldering
 ## Diodes
-**Orientation**: place the diode with the black bar towrds the white bar indicator on the pcb.
-1. Solder one pad.
-![one pad - diode](https://imgur.com/4xkhNLN.jpg)
+**Orientation**: place the diode with the black bar towrds the white bar
+indicator on the pcb.
+1. Solder one pad. ![one pad - diode](https://imgur.com/4xkhNLN.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://imgur.com/ebNhsk3.jpg)
-3. Solder other pad.
-![diode complete](https://imgur.com/xgMnV9D.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://imgur.com/xgMnV9D.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://imgur.com/Vzn1JnV.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://imgur.com/NWXUwe0.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://imgur.com/4jkgbsp.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://imgur.com/Vzn1JnV.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://imgur.com/NWXUwe0.jpg)
+3. Solder other pad. ![Hot swap socket finished](https://imgur.com/4jkgbsp.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: microcontroller face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://imgur.com/RvOAjJe.jpg)
-2. Place microcontroller face down. 
-![microcontroller placed](https://imgur.com/0NZEMJe.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://imgur.com/RvOAjJe.jpg)
+2. Place microcontroller face down. ![microcontroller
+placed](https://imgur.com/0NZEMJe.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://imgur.com/Nuecurb.jpg)
@@ -70,29 +72,41 @@ you may need to reflow and add more solder a couple times before an adequate con
 ## Misc.
 
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://imgur.com/HfQZimm.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://imgur.com/CUYsUdS.jpg)
+1. Solder one pad. ![reset switch placed](https://imgur.com/HfQZimm.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch placed](https://imgur.com/CUYsUdS.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under QMKKEYBOARDNAME.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under QMKKEYBOARDNAME. #TODO To begin, follow
+the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working
+from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
-
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/lulu.md
+++ b/build_guides/lulu.md
@@ -12,17 +12,28 @@ banner: https://boardsource.imgix.net/a49277b0-28d9-11ed-8771-8b53559ba1bf.jpg
 thumbnail: https://boardsource.imgix.net/a8107ae0-28d9-11ed-bdbc-ab99b282b508.jpg?auto=format&ixlib=react-9.2.0&q=80&w=200&dpr=1
 ---
 
-Welcome to the lulu build guide, here you will find a step by step guide on how to build your lulu as well as a list of items your kit(s) should contain. Please follow this guide in its entirety, if you have any questions or need more hands-on help you can [enter the Discord](https://discord.gg/b4R25WSZvH) and ask under the #build-help channel. 
+Welcome to the lulu build guide, here you will find a step by step guide on how
+to build your lulu as well as a list of items your kit(s) should contain. Please
+follow this guide in its entirety, if you have any questions or need more
+hands-on help you can [enter the Discord](https://discord.gg/b4R25WSZvH) and ask
+under the #build-help channel.
 
-We recommend you do each step on both halves of the keyboard prior to moving on to the next step, but of course you can also complete a side and then do the next, the choice is yours.
+We recommend you do each step on both halves of the keyboard prior to moving on
+to the next step, but of course you can also complete a side and then do the
+next, the choice is yours.
 
-**IMPORTANT:** When using a split keyboard, it is extremely important that you plug in the halves and then the board to your computer in the correct order. This is the correct order to follow: 
+**IMPORTANT:** When using a split keyboard, it is extremely important that you
+plug in the halves and then the board to your computer in the correct order.
+This is the correct order to follow:
 
-Plugging In the Board: First connect the halves via TRRS, then plug the board into your computer via USB. 
+Plugging In the Board: First connect the halves via TRRS, then plug the board
+into your computer via USB.
 
-Unplugging The Board: Disconnect the board from your computer, then unplug the halves TRRS connection. 
+Unplugging The Board: Disconnect the board from your computer, then unplug the
+halves TRRS connection.
 
-**DO NOT PLUG/UNPLUG THE TRRS CABLE WHEN THE BOARD IS PLUGGED IN TO YOUR COMPUTER**
+**DO NOT PLUG/UNPLUG THE TRRS CABLE WHEN THE BOARD IS PLUGGED IN TO YOUR
+COMPUTER**
 
 ## Quick Links
 * [Flashing Guide](https://boardsource.xyz/help/6306d4840b62f46fa9448c0b)
@@ -41,8 +52,9 @@ Unplugging The Board: Disconnect the board from your computer, then unplug the h
 * 1.5mm Allen (Hex) Key
 
 **lulu SMT PCB**
-* lulu SMT Hotswap PCB
-Note: Your PCB box is unsealed and the anti static bag is open because we had to re-flash some PCBs that did not have the bootloader written to them correctly. 
+* lulu SMT Hotswap PCB Note: Your PCB box is unsealed and the anti static bag is
+open because we had to re-flash some PCBs that did not have the bootloader
+written to them correctly.
 
 **Tenting Kit**
 * 2x 10° Tenting Legs
@@ -60,16 +72,19 @@ Note: Your PCB box is unsealed and the anti static bag is open because we had to
 
 **Other Items Required - Not Included**
 * 58 MX Switches (or 56 if you’re using a Rotary Encoder Kit)
-* P0 Phillips Screwdriver (P1 size also may work but is more likely to strip screws)
+* P0 Phillips Screwdriver (P1 size also may work but is more likely to strip
+  screws)
 *  For Encoder Kit Only:
     - Soldering Iron
     - Solder
 
-If you’re missing a piece in a kit, please reach out to us at help@boardsource.xyz and we will get you the part sent out ASAP. 
+If you’re missing a piece in a kit, please reach out to us at
+help@boardsource.xyz and we will get you the part sent out ASAP.
 
 ## Install OLED Cover and Plug Into Aluminum Top Case
 
-![oled plug](https://boardsource.imgix.net/d61c0a30-704c-11ec-8d83-278e60308b52.gif)
+![oled
+plug](https://boardsource.imgix.net/d61c0a30-704c-11ec-8d83-278e60308b52.gif)
 
 **Required Parts In This Section:**
 * 2x aluminum top case
@@ -77,43 +92,95 @@ If you’re missing a piece in a kit, please reach out to us at help@boardsource
 * 2x OLED plug
 * 4x m2x6mm flat head bolt
 
-From the backside of the top case (front laying down on a surface) insert the OLED Cover into the OLED window. Line up the cutouts on the OLED cover with the posts on the aluminum. You can apply a bit of force in order to fully seat it. When you think the cover is fully seated, inspect the cover from the front, the cover should be close to flush with the aluminum.  If it seems to be inset too much, you likely installed the cover upside down. 
+From the backside of the top case (front laying down on a surface) insert the
+OLED Cover into the OLED window. Line up the cutouts on the OLED cover with the
+posts on the aluminum. You can apply a bit of force in order to fully seat it.
+When you think the cover is fully seated, inspect the cover from the front, the
+cover should be close to flush with the aluminum. If it seems to be inset too
+much, you likely installed the cover upside down.
 
-Again from the back of the top case, inset the OLED Retention Plug into the case. There is only one correct orientation for this piece, simply align the cutouts on the piece with the posts on the aluminum and insert. Fasten the OLED retention plug to the top case with the conical flush head phillips screws in the Case Kit Box. Tighten the retention plug until it is flush with the aluminum. Do not over tighten the OLED Retention Plug or cracking may occur. 
+Again from the back of the top case, inset the OLED Retention Plug into the
+case. There is only one correct orientation for this piece, simply align the
+cutouts on the piece with the posts on the aluminum and insert. Fasten the OLED
+retention plug to the top case with the conical flush head phillips screws in
+the Case Kit Box. Tighten the retention plug until it is flush with the
+aluminum. Do not over tighten the OLED Retention Plug or cracking may occur.
 
-With the OLED Retention Plug properly installed and fastened, you can make small final adjustments by hand to the OLED Cover to ensure the final fit is flush with the aluminum on the top side. Slight movements will not cause any cracking and the cover should stay in place.
+With the OLED Retention Plug properly installed and fastened, you can make small
+final adjustments by hand to the OLED Cover to ensure the final fit is flush
+with the aluminum on the top side. Slight movements will not cause any cracking
+and the cover should stay in place.
 
-PRO TIP: Prior to moving on, clean the OLED Cover to remove any smudges or marks you made during installation. The clear OLED Cover is easily scratched, we recommended using a glasses cleaning cloth/microfiber cloth, do not apply too much pressure when cleaning. The underside will be hard to get to later, so it’s best to clean it now.
+PRO TIP: Prior to moving on, clean the OLED Cover to remove any smudges or marks
+you made during installation. The clear OLED Cover is easily scratched, we
+recommended using a glasses cleaning cloth/microfiber cloth, do not apply too
+much pressure when cleaning. The underside will be hard to get to later, so it’s
+best to clean it now.
  
 ## Install Encoder Plug
 
-![encoder plug](https://boardsource.imgix.net/29caec00-704d-11ec-8546-2f1606942334.gif)
+![encoder
+plug](https://boardsource.imgix.net/29caec00-704d-11ec-8546-2f1606942334.gif)
 
-**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit, if you did not then simply move on to the next step.
+**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit,
+if you did not then simply move on to the next step.
 
 **Required Parts In This Section:**
 * 2x Aluminum Top Case
 * 2x Encoder Plug
 
-Now we are going to insert the Encoder Plugs into the Aluminum Top Case. It is important to differentiate the left plug from the right plug, as they are not the same. Forcing the incorrect plug into the wrong side may cause damage to the plug. 
+Now we are going to insert the Encoder Plugs into the Aluminum Top Case. It is
+important to differentiate the left plug from the right plug, as they are not
+the same. Forcing the incorrect plug into the wrong side may cause damage to the
+plug.
 
-If you inspect the Encoder Plugs closely, you will notice each plug has 3 corners that are 90° corners, and one is a bit weird with an angle. That angle is meant to match the ‘pointy bit’ of aluminum that sits above the thumb key on each half of the lulu. Additionally, if you inspect the sidewalls of the Encoder Plug you will notice one has a small cutout towards the bottom. This cutout helps with removal of this plug in the future. On each half, that cutout is supposed to face towards the keys. In other words, the left plug’s cutout faces left, and the right plug’s cutout faces right when installed properly. 
+If you inspect the Encoder Plugs closely, you will notice each plug has 3
+corners that are 90° corners, and one is a bit weird with an angle. That angle
+is meant to match the ‘pointy bit’ of aluminum that sits above the thumb key on
+each half of the lulu. Additionally, if you inspect the sidewalls of the Encoder
+Plug you will notice one has a small cutout towards the bottom. This cutout
+helps with removal of this plug in the future. On each half, that cutout is
+supposed to face towards the keys. In other words, the left plug’s cutout faces
+left, and the right plug’s cutout faces right when installed properly.
 
-Let’s check which plug is which by confirming where the ‘weird angled corner’ lines up when you orient the cutout correct. When oriented properly, the left half’s Encoder Plug will have its weird corner in the bottom left, and when the cutout on the right Encoder Plug is oriented correct it will have its weird corner in the bottom right. 
+Let’s check which plug is which by confirming where the ‘weird angled corner’
+lines up when you orient the cutout correct. When oriented properly, the left
+half’s Encoder Plug will have its weird corner in the bottom left, and when the
+cutout on the right Encoder Plug is oriented correct it will have its weird
+corner in the bottom right.
 
-When in doubt, sit back, take a deep breath, and imagine how this piece would look if you inserted it into the key switch location. The weird corner’s angle should CONTINUE the angle of the pointy aluminum, not interfere or intersect with it. I am sorry this is semi difficult to explain, we will add some pictures in the future. 
+When in doubt, sit back, take a deep breath, and imagine how this piece would
+look if you inserted it into the key switch location. The weird corner’s angle
+should CONTINUE the angle of the pointy aluminum, not interfere or intersect
+with it. I am sorry this is semi difficult to explain, we will add some pictures
+in the future.
 
-Now that you’re (hopefully) sure which half the Encoder Plug belongs to figured out, we can start inserting them into the key switch location. Make sure the key switch location is clear of any debris prior to installation or it will cause the plug to sit proud of the aluminum. 
+Now that you’re (hopefully) sure which half the Encoder Plug belongs to figured
+out, we can start inserting them into the key switch location. Make sure the key
+switch location is clear of any debris prior to installation or it will cause
+the plug to sit proud of the aluminum.
 
-Place the Encoder Plug into the key switch location and let it rest. Check to make sure it’s aligned properly by looking straight down on it, and try to ensure the top of the plug is laying flat, not at an angle. With even force apply downward pressure onto the plug, it should click into place. If you aren’t able to seat the plug, one of two things are happening, either you aren’t applying enough force, or you’re using the wrong side’s plug. Before attempting installation again, double check the orientation of the plug, realign it, and apply even downward pressure again. This takes a bit of force, but gets easier after use if you remove/re-insert it over time.
+Place the Encoder Plug into the key switch location and let it rest. Check to
+make sure it’s aligned properly by looking straight down on it, and try to
+ensure the top of the plug is laying flat, not at an angle. With even force
+apply downward pressure onto the plug, it should click into place. If you aren’t
+able to seat the plug, one of two things are happening, either you aren’t
+applying enough force, or you’re using the wrong side’s plug. Before attempting
+installation again, double check the orientation of the plug, realign it, and
+apply even downward pressure again. This takes a bit of force, but gets easier
+after use if you remove/re-insert it over time.
 
-When installed properly the Encoder Plug should sit flush with the aluminum. If it does not sit flush, you can try applying a bit more force. If issues persist, remove the encoder plug and inspect the plug and surrounding areas for any debris.
+When installed properly the Encoder Plug should sit flush with the aluminum. If
+it does not sit flush, you can try applying a bit more force. If issues persist,
+remove the encoder plug and inspect the plug and surrounding areas for any
+debris.
 
 ## Solder Encoder to PCB
 
 ![encoder](https://boardsource.imgix.net/322faa20-704d-11ec-8546-2f1606942334.gif)
 
-**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit, if you did not then simply move on to the next step.
+**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit,
+if you did not then simply move on to the next step.
 
 **Required Parts In This Section:**
 * 2x Rotary Encoders
@@ -121,17 +188,36 @@ When installed properly the Encoder Plug should sit flush with the aluminum. If 
 * Soldering Iron
 * Solder
 
-Prior to installing the Rotary Encoder onto the PCB, check to make sure each of the connection legs on the encoder are straight. They are fairly easy to bend and this causes issues during installation. Simply straighten each leg out to help with easy installation.
+Prior to installing the Rotary Encoder onto the PCB, check to make sure each of
+the connection legs on the encoder are straight. They are fairly easy to bend
+and this causes issues during installation. Simply straighten each leg out to
+help with easy installation.
 
-The rotary encoder can only be placed onto the PCB in one orientation, make sure to match up the number of legs with the number of holes on the PCB. The 3 pins should point down towards the thumb clusters. Insert the rotary encoder into the PCB and make sure that it is fully seated and resting on the PCB flat. Improper/uneven installation will cause fitment issues elsewhere.
+The rotary encoder can only be placed onto the PCB in one orientation, make sure
+to match up the number of legs with the number of holes on the PCB. The 3 pins
+should point down towards the thumb clusters. Insert the rotary encoder into the
+PCB and make sure that it is fully seated and resting on the PCB flat.
+Improper/uneven installation will cause fitment issues elsewhere.
 
-With the rotary encoder properly installed on the PCB, flip the PCB over and solder the 5 connection leads, and then solder the 2 retention legs. It is smart to periodically flip the PCB over to confirm the encoder is fully seated onto the PCB and resting on it and did not raise or move at all.  Be careful not to heat the pads near the hot swap socket too much, and you do not need to apply an abundance of solder. Nothing bad will happen if you burn the hot swap socket, but it may cause a bit of an ugly mark. It is very possible to solder all leads without disturbing the hot swap socket.
+With the rotary encoder properly installed on the PCB, flip the PCB over and
+solder the 5 connection leads, and then solder the 2 retention legs. It is smart
+to periodically flip the PCB over to confirm the encoder is fully seated onto
+the PCB and resting on it and did not raise or move at all. Be careful not to
+heat the pads near the hot swap socket too much, and you do not need to apply an
+abundance of solder. Nothing bad will happen if you burn the hot swap socket,
+but it may cause a bit of an ugly mark. It is very possible to solder all leads
+without disturbing the hot swap socket.
 
 ## Install OLED-S
 
-**Note:** This section is only applicable if you purchased OLED-S with your lulu, if not move on to the next step.
+**Note:** This section is only applicable if you purchased OLED-S with your
+lulu, if not move on to the next step.
 
-Unpackage the OLED-S from the anti-static bag it comes in. Install OLED-S into the 4 header pin sockets (in one strip) on the front of the PCB below the microcontroller. Simply align the posts on the OLED-S with the header piin sockets, and apply downward pressure. When fully inserted into the sockets, you can bend the pins slightly if you need to make it more level.
+Unpackage the OLED-S from the anti-static bag it comes in. Install OLED-S into
+the 4 header pin sockets (in one strip) on the front of the PCB below the
+microcontroller. Simply align the posts on the OLED-S with the header piin
+sockets, and apply downward pressure. When fully inserted into the sockets, you
+can bend the pins slightly if you need to make it more level.
 
 ## Insert Alignment Switches Into Plate
 
@@ -141,7 +227,13 @@ Unpackage the OLED-S from the anti-static bag it comes in. Install OLED-S into t
 * 2x Aluminum Top Case
 * ~8x Switches of Your Choice
 
-To help connect the PCB to the plate/switches, it helps to put a few switches through the plate first. This allows you to have a few switches per half help hold up the PCB. Simply insert 4-6 switches per half, trying to get them in all four corners and not all in the same spot.  If you’re looking at the top case with the number row facing up, the switch legs too should face ‘up.’ Take a look at the PCB, imagine how the switches go into the hot swap sockets in the next step, and confirm you’re orienting the switches into the plate properly. 
+To help connect the PCB to the plate/switches, it helps to put a few switches
+through the plate first. This allows you to have a few switches per half help
+hold up the PCB. Simply insert 4-6 switches per half, trying to get them in all
+four corners and not all in the same spot. If you’re looking at the top case
+with the number row facing up, the switch legs too should face ‘up.’ Take a look
+at the PCB, imagine how the switches go into the hot swap sockets in the next
+step, and confirm you’re orienting the switches into the plate properly.
 
 ## Connect PCB to Switches and Plate
 
@@ -150,42 +242,95 @@ To help connect the PCB to the plate/switches, it helps to put a few switches th
 **Required Parts In This Section:**
 * 2x Aluminum Top Case
 * 2x PCB Halves
-* Plate Foam (Optional) 
+* Plate Foam (Optional)
 
-If you have not snapped away the permitter pieces on your PCBs yet, do so at this time. You can simply use your hands and snap them off, pliers can help a bit if small remnants are left behind. The PCBs must be totally separated from one another for this to work.
+If you have not snapped away the permitter pieces on your PCBs yet, do so at
+this time. You can simply use your hands and snap them off, pliers can help a
+bit if small remnants are left behind. The PCBs must be totally separated from
+one another for this to work.
 
-Lay your top case (with alignment switches installed) face down onto the table. You should not see the colored switch stem, that’s against the table. You should see the legs of the switches from this view.
+Lay your top case (with alignment switches installed) face down onto the table.
+You should not see the colored switch stem, that’s against the table. You should
+see the legs of the switches from this view.
 
-NOTE: If you’re using plate foam, you’re going to need to install that now. When the top case upside down, insert it into the top case in the proper orientation. You should see it align perfectly with the curves of the case and the switch holes.
+NOTE: If you’re using plate foam, you’re going to need to install that now. When
+the top case upside down, insert it into the top case in the proper orientation.
+You should see it align perfectly with the curves of the case and the switch
+holes.
 
-Now you may place the PCB for that half on top of the alignment switches, doing your best to align the hot swap sockets with the switch legs. You can sometimes feel it ‘drop’ a TINY bit into place, this means you aligned it well and the switch legs are ready to be inserted into the hot swap sockets. Press down on  each hot swap socket that has an alignment switch inserted. You should be able to feel the PCB push down and see the ends of the switch legs through the hot swap socket. Do this for each alignment switch. 
+Now you may place the PCB for that half on top of the alignment switches, doing
+your best to align the hot swap sockets with the switch legs. You can sometimes
+feel it ‘drop’ a TINY bit into place, this means you aligned it well and the
+switch legs are ready to be inserted into the hot swap sockets. Press down on
+each hot swap socket that has an alignment switch inserted. You should be able
+to feel the PCB push down and see the ends of the switch legs through the hot
+swap socket. Do this for each alignment switch.
 
-When each alignment switch is properly inserted into the top case, and each hot swap socket is properly seated, you should be able to pick up the assembly and it won’t drop or fall. The PCB, switches, plate, and top case are now all connected via these alignment switches. You can press them all together once more to ensure proper installation. If one does not seat properly or something isn’t looking quite right, make sure the switch is oriented properly, there are four possible directions a switch can be inserted, and only one is correct to line up with the holes in the hot swap socket. Even if inserted properly, it is also possible the switch legs are bent, this will also cause the switch to not seat properly. Do not use too much pressure or force anything when performing this step. A reasonable amount of force can be used to seat the switches into the hot swap socket, but if you’re forcing anything or pressing too hard it means something is wrong, and you run the risk of popping a hot swap socket off the PCB. 
+When each alignment switch is properly inserted into the top case, and each hot
+swap socket is properly seated, you should be able to pick up the assembly and
+it won’t drop or fall. The PCB, switches, plate, and top case are now all
+connected via these alignment switches. You can press them all together once
+more to ensure proper installation. If one does not seat properly or something
+isn’t looking quite right, make sure the switch is oriented properly, there are
+four possible directions a switch can be inserted, and only one is correct to
+line up with the holes in the hot swap socket. Even if inserted properly, it is
+also possible the switch legs are bent, this will also cause the switch to not
+seat properly. Do not use too much pressure or force anything when performing
+this step. A reasonable amount of force can be used to seat the switches into
+the hot swap socket, but if you’re forcing anything or pressing too hard it
+means something is wrong, and you run the risk of popping a hot swap socket off
+the PCB.
 
 ## Install Knob Onto Rotary Encoder
 
-**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit, if you did not then simply move on to the next step.
+**NOTE:** This section is only applicable if you purchased a Rotary Encoder Kit,
+if you did not then simply move on to the next step.
 
 ![knob](https://boardsource.imgix.net/5d243750-704d-11ec-a2da-010e6cffaa5a.gif)
 
 **Required Parts In This Section:**
 * 2x Encoder Knob
 
-With the PCB attached to the top case assembly via switches, if you have a rotary encoder installed on your PCB you should now see the stem from the top side through the Encoder Plug. If this doesn’t seem to fit, ensure your rotary encoder is properly seated against the PCB and is completely flat. 
+With the PCB attached to the top case assembly via switches, if you have a
+rotary encoder installed on your PCB you should now see the stem from the top
+side through the Encoder Plug. If this doesn’t seem to fit, ensure your rotary
+encoder is properly seated against the PCB and is completely flat.
 
-Simply insert the Rotary Encoder Knob onto the Rotary Encoder Stem. The Knob can only be placed onto the stem in a single direction, check to ensure proper alignment prior to applying pressure. The steam has a single flat side, and the interior of the knob has a single flat side. Line them up and then apply downward force. This takes some pressure and is a friction fit, support the PCB from the back when installing the Knob to make sure you don’t push the PCB away from the switches and cause them to disconnect. 
+Simply insert the Rotary Encoder Knob onto the Rotary Encoder Stem. The Knob can
+only be placed onto the stem in a single direction, check to ensure proper
+alignment prior to applying pressure. The steam has a single flat side, and the
+interior of the knob has a single flat side. Line them up and then apply
+downward force. This takes some pressure and is a friction fit, support the PCB
+from the back when installing the Knob to make sure you don’t push the PCB away
+from the switches and cause them to disconnect.
 
-You will likely hear a click, that is okay it is the ‘press down’ function of the rotary encoder and makes a clicking noise, nothing broke. Use a bit of pressure even past that click and fully seat the knob onto the stem. You should not have to use an extreme amount of pressure or force the knob onto the stem. If you feel like it isn’t going onto the stem, pleasure confirm the proper orientation of the knob by aligned the flat surfaces. Forcing the knob onto the stem in the wrong orientation can crack the knob. 
+You will likely hear a click, that is okay it is the ‘press down’ function of
+the rotary encoder and makes a clicking noise, nothing broke. Use a bit of
+pressure even past that click and fully seat the knob onto the stem. You should
+not have to use an extreme amount of pressure or force the knob onto the stem.
+If you feel like it isn’t going onto the stem, pleasure confirm the proper
+orientation of the knob by aligned the flat surfaces. Forcing the knob onto the
+stem in the wrong orientation can crack the knob.
 
 ## Insert Remainder of Switches
 
-![rest of switches](https://boardsource.imgix.net/773d9500-704d-11ec-88ec-df9325c6e667.gif)
+![rest of
+switches](https://boardsource.imgix.net/773d9500-704d-11ec-88ec-df9325c6e667.gif)
 
-Now, you can go through the remainder of the of the switches and insert them into the assembly from the front. Remember, there is only one way a switch can be inserted properly, so double check the orientation prior to installation and also confirm the switch legs are straight. SUPPORT EACH HOT SWAP SOCKET FROM THE BACK WHEN INSERTING SWITCHES. I use my fingers to support the hot swap from the back while I press the switch in from the front and go one by one. If you do not support hot swap sockets from the back during switch installation, it is possible they will pop off the PCB causing permanent damage. Ensure each switch is fully seated into the plate and hotswap socket.
+Now, you can go through the remainder of the of the switches and insert them
+into the assembly from the front. Remember, there is only one way a switch can
+be inserted properly, so double check the orientation prior to installation and
+also confirm the switch legs are straight. SUPPORT EACH HOT SWAP SOCKET FROM THE
+BACK WHEN INSERTING SWITCHES. I use my fingers to support the hot swap from the
+back while I press the switch in from the front and go one by one. If you do not
+support hot swap sockets from the back during switch installation, it is
+possible they will pop off the PCB causing permanent damage. Ensure each switch
+is fully seated into the plate and hotswap socket.
 
 ## Install Tenting Legs
 
-**NOTE:** This section is only applicable if you purchased a Tenting Kit, if you did not then simply move on to the next step.
+**NOTE:** This section is only applicable if you purchased a Tenting Kit, if you
+did not then simply move on to the next step.
 
 ![tenting](https://boardsource.imgix.net/83bb0fb0-704d-11ec-8d83-278e60308b52.gif)
 
@@ -194,30 +339,73 @@ Now, you can go through the remainder of the of the switches and insert them int
 * 2x Tenting Legs in the angle of your choice
 *  4x M2 x 4mm Conical Flush Head Phillips Screw
 
-Take a single screw and place it into the appropriate hole on the interior of the lower piece. Using three hands, hold that screw in place with your screwdriver while you properly align the tenting leg with the screw from the other side. Tighten the screw to fasten the tenting leg to the lower piece. Insert the other screw and attach the other side of the tenting leg to the lower bottom piece.
+Take a single screw and place it into the appropriate hole on the interior of
+the lower piece. Using three hands, hold that screw in place with your
+screwdriver while you properly align the tenting leg with the screw from the
+other side. Tighten the screw to fasten the tenting leg to the lower piece.
+Insert the other screw and attach the other side of the tenting leg to the lower
+bottom piece.
 
-Do not over tighten screws, if you try to lock these down with an immense amount of force, it is possible to unset the threaded insert in the tenting leg. However, it is totally fine to tighten them enough where you ensure there is zero movement or wobble in the tenting leg. When properly tightened the tenting leg should not move at all.
+Do not over tighten screws, if you try to lock these down with an immense amount
+of force, it is possible to unset the threaded insert in the tenting leg.
+However, it is totally fine to tighten them enough where you ensure there is
+zero movement or wobble in the tenting leg. When properly tightened the tenting
+leg should not move at all.
 ## Finale Keyboard Assembly 
 
 ![final](https://boardsource.imgix.net/8c586a00-704d-11ec-8d83-278e60308b52.gif)
 
 **Required Parts In This Section:**
 * 2x PC Bottom Pieces with Tenting Legs Installed (If Applicable)
-* 2x Aluminum Top Case with PCB, Switches, OLED, OLED Covers, and OLED Plugs Installed
+* 2x Aluminum Top Case with PCB, Switches, OLED, OLED Covers, and OLED Plugs
+  Installed
 * 8x M2x6mm Cap Head Bolt
 * 1.5mm Allen (Hex) Key
 
-Lay the Aluminum Top Case upside down on a surface (resting on the switches) then align the polycarbonate lower piece on top of it. The pieces should align themselves and you will see the threaded posts through the holes on the lower piece. Connect the pieces together using the Hex Cap Head Bolts, 4 per half. Do not over tighten these bolts, as too much pressure may cause gaps. Just snug them up and everything should be secure and aligned properly.
+Lay the Aluminum Top Case upside down on a surface (resting on the switches)
+then align the polycarbonate lower piece on top of it. The pieces should align
+themselves and you will see the threaded posts through the holes on the lower
+piece. Connect the pieces together using the Hex Cap Head Bolts, 4 per half. Do
+not over tighten these bolts, as too much pressure may cause gaps. Just snug
+them up and everything should be secure and aligned properly.
 
 ## Enjoy your keyboard
 
-Install some keycaps and post up a picture on Reddit/discord/Instagram and tag us.
- We hope you enjoy your keyboard if you have any questions we have a build help section in our discord hop in and there are loads of helpful people in there at all hours of the day ready to help.
+Install some keycaps and post up a picture on Reddit/discord/Instagram and tag
+ us. We hope you enjoy your keyboard if you have any questions we have a build
+ help section in our discord hop in and there are loads of helpful people in
+ there at all hours of the day ready to help.
 
-## Enjoy Your lulu   8)   :)   <3
+## Firmware
 
-Install some nice caps and post a picture somewhere, tag us if you don’t mind. Extras will be available in about 1 month, and the lulu should be consistently stocked in about 3 months.
+### QMK
+In qmk this keyboard can be found under boardsource/lulu/avr. To begin, follow
+the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working
+from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
-Remember, if you have questions or need additional help, please [enter the Discord](https://discord.gg/b4R25WSZvH) and ask under the #build-help section. 
+### KMK / PEG
+In Peg or KMK this keyboard can be found under lily58 or boardsource-lulu-blok
+in Peg
 
-If you think you’re missing a piece or have a question unrelated to building your keyboard, email us at help@boardsource.xyz.
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
+
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/microdox.md
+++ b/build_guides/microdox.md
@@ -23,17 +23,17 @@ thumbnail: https://boardsource.imgix.net/66d714f0-50bf-11ec-a609-016ae228379c.jp
 | SMD Diodes (SOD-123) | 36 |
 | PCB | 2 |
 | Pro Micro or similar microcontroller | 2 |
-| TRRS Jack | 2 | 
-| TRRS Cable | 1 | 
-| Reset Switch | 2 | 
-| MX or Choc Hotswap Sockets | 36 | 
-| MX or Choc Switches | 36 | 
+| TRRS Jack | 2 |
+| TRRS Cable | 1 |
+| Reset Switch | 2 |
+| MX or Choc Hotswap Sockets | 36 |
+| MX or Choc Switches | 36 |
 | MX or Choc Keycaps | 36 |
 
 ### Optional 
-| Item | Count | 
+| Item | Count |
 |------|-------|
-| 128x32 OLED Display | 2 | 
+| 128x32 OLED Display | 2 |
 | SK6812 Mini-E LED | 36 |
 | WS2812B LED | 8 |
 | EC11 Encoder + Knob | 2 |
@@ -44,39 +44,46 @@ thumbnail: https://boardsource.imgix.net/66d714f0-50bf-11ec-a609-016ae228379c.jp
 # Soldering
 ## Diodes
 **Orientation**: Black bar facing downwards or towards the microcontroller.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/BpFs8hm.jpeg)
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/BpFs8hm.jpeg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/6RBHm6E.jpeg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/SZJ47Yw.jpeg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/SZJ47Yw.jpeg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 ## LEDs
-**Orientation**: Notched corner/pin facing the pad marked with rectangle. This applies for both SK6812 Mini-E & WS2812B LEDs.
-![sk6812 mini e orientation](https://i.imgur.com/EIdOVwT.jpeg)
-![ws2812b orientation](https://i.imgur.com/pXG8wGq.jpeg)
-- Notes: \
-\- This component is heat sensitive. Be cautious and work at a safe temp (~300c). \
-\- It is wise to test the LEDs as you solder then. Consider [soldering your controllers beforehand](https://github.com/waffle87/microdox/blob/master/v2_guide.md#microcontrollers). \
-\- The LED order is somewhat outlined [here](https://github.com/qmk/qmk_firmware/blob/master/keyboards/boardsource/microdox/v2/v2.c#L8-#L17) and should be followed in order when building.
-1. Solder one pad. (it may be easier to solder all 4 pads before placing LED down when installing WS2812B LEDs)
-![sk6812 mini e one pad](https://i.imgur.com/N3e43eK.jpeg)
-![ws2812b 4 pads](https://i.imgur.com/eAuOY2N.jpeg)
+**Orientation**: Notched corner/pin facing the pad marked with rectangle. This
+applies for both SK6812 Mini-E & WS2812B LEDs. ![sk6812 mini e
+orientation](https://i.imgur.com/EIdOVwT.jpeg) ![ws2812b
+orientation](https://i.imgur.com/pXG8wGq.jpeg)
+- Notes: \ \- This component is heat sensitive. Be cautious and work at a safe
+temp (~300c). \ \- It is wise to test the LEDs as you solder then. Consider
+[soldering your controllers
+beforehand](https://github.com/waffle87/microdox/blob/master/v2_guide.md#microcontrollers).
+\ \- The LED order is somewhat outlined
+[here](https://github.com/qmk/qmk_firmware/blob/master/keyboards/boardsource/microdox/v2/v2.c#L8-#L17)
+and should be followed in order when building.
+1. Solder one pad. (it may be easier to solder all 4 pads before placing LED
+down when installing WS2812B LEDs) ![sk6812 mini e one
+pad](https://i.imgur.com/N3e43eK.jpeg) ![ws2812b 4
+pads](https://i.imgur.com/eAuOY2N.jpeg)
 2. While holding LED with tweezers, reflow solder and place LED down on pad.
-![sk6812 mini e placed](https://i.imgur.com/UNA4BMb.jpeg)
-![ws2812b placed](https://i.imgur.com/tATAmL8.jpeg)
-3. Solder remaining pads.
-![sk6812 mini e complete](https://i.imgur.com/MTQPwNv.jpeg)
+![sk6812 mini e placed](https://i.imgur.com/UNA4BMb.jpeg) ![ws2812b
+placed](https://i.imgur.com/tATAmL8.jpeg)
+3. Solder remaining pads. ![sk6812 mini e
+complete](https://i.imgur.com/MTQPwNv.jpeg)
 
 ## Microcontrollers
 **Orientation**: Both microcontrollers face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](https://github.com/waffle87/microdox/blob/master/v2_guide.md#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/tKdrLvl.jpeg)
-2. Place microcontroller face down. (smooth side facing up)
-![microcontroller placed](https://i.imgur.com/4gblRIt.jpeg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](https://github.com/waffle87/microdox/blob/master/v2_guide.md#firmware)
+  section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/tKdrLvl.jpeg)
+2. Place microcontroller face down. (smooth side facing up) ![microcontroller
+placed](https://i.imgur.com/4gblRIt.jpeg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 
@@ -92,21 +99,60 @@ you may need to reflow and add more solder a couple times before an adequate con
 2. Apply solder to all four pins.
 ### Reset switches
 1. Solder one pad.
-2. While holding switch with tweezers, refolw solder and place switch down on pad.
+2. While holding switch with tweezers, refolw solder and place switch down on
+   pad.
 3. Solder remaining 3 pads.
 ### Hotswap sockets
 1. Solder one pad.
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+   socket down on pad.
 3. Solder other pad.
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 ### Encoders
 1. Secure in place using tape or hands.
 2. Apply solder to all five pins.
 
 ## Firmware
-- Note, default/v1 microdox firmware is not compatible with v2 PCBs. \
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+- Note, default/v1 microdox firmware is not compatible with v2 PCBs. \ To begin,
+follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if
+working from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+## Firmware
+
+### QMK
+- Note, default/v1 microdox firmware is not compatible with v2 PCBs. \ To begin,
+follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if
+working from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under lily58 or boardsource-lulu-blok
+in Peg
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
+
 
 #### Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/ortho.md
+++ b/build_guides/ortho.md
@@ -18,161 +18,327 @@ thumbnail: https://boardsource.imgix.net/83048f2a-4080-475f-a048-370f6db441eb.jp
 #### This build guide teaches you how to build the high profile and low profile versions of both the 4x12 and 5x12 Ortho boards listed on Boardsource. Both sizes of each version of the board are built the same way, the only difference of course being that there is one additional row on the 5x12, the low profile versions use different hotswap sockets, but the installation principles are the same.
 
 ## IMPORTANT NOTE
-**If the area underneath your controller on the backside of the PCB says 'Face Up' then you have the new version of the PCB with edits made. These edits make it so that the micro controller is installed with the components face up on the PCB. The old version of the PCB which does NOT say 'Face Up' must have the controller installed face down with the blank side up. If you need help determining which version of the PCB you have please reach out on Discord. Sorry for any inconveniences this may cause.**
+**If the area underneath your controller on the backside of the PCB says 'Face
+Up' then you have the new version of the PCB with edits made. These edits make
+it so that the micro controller is installed with the components face up on the
+PCB. The old version of the PCB which does NOT say 'Face Up' must have the
+controller installed face down with the blank side up. If you need help
+determining which version of the PCB you have please reach out on Discord. Sorry
+for any inconveniences this may cause.**
 
 ## Kit Contents
 * Ortho PCB (the size/version depends on what you purchased)
 * FR4 Backplate (1)
 * FR4 Plate (1)
-*  [Elite-C / Pro Micro (optional) (1)](https://boardsource.xyz/store/5eca03e264caf04f83aa6476)
+*  [Elite-C / Pro Micro (optional)
+   (1)](https://boardsource.xyz/store/5eca03e264caf04f83aa6476)
 * Threaded Standoffs (5)
 * [M2 Screws (5)](https://boardsource.xyz/store/5ecad60fe7e0515b382b553b)
 * [Diodes (50 or 60)](https://boardsource.xyz/store/5ec9fc5d64caf04f83aa646c)
-* [Hotswap Sockets (50 or 60)](https://boardsource.xyz/store/5eca066464caf04f83aa647f)
+* [Hotswap Sockets (50 or
+  60)](https://boardsource.xyz/store/5eca066464caf04f83aa647f)
 * Rubber Feet (4)
 
 # Step 1: Check Kit Contents
-![ortho kit](https://boardsource.imgix.net/e36766a6-e416-4944-8638-14e1174ef082.jpg)
+![ortho
+kit](https://boardsource.imgix.net/e36766a6-e416-4944-8638-14e1174ef082.jpg)
 
 
-Prior to starting any build it is important to take a look at what you received and what you have in front of you. Nothing is more frustrating than getting halfway through a build and realizing you’re missing a single hotswap socket or a screw, or anything for that matter. If you think we forgot to ship something, or if you may have accidentally misplaced something, please reach out to us on [Discord](https://discord.gg/FTun6Cy) in the Help section, or [Submit A Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account section of Boardsource. 
+Prior to starting any build it is important to take a look at what you received
+and what you have in front of you. Nothing is more frustrating than getting
+halfway through a build and realizing you’re missing a single hotswap socket or
+a screw, or anything for that matter. If you think we forgot to ship something,
+or if you may have accidentally misplaced something, please reach out to us on
+[Discord](https://discord.gg/FTun6Cy) in the Help section, or [Submit A
+Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account
+section of Boardsource.
 
-Note: Boardsource often includes extras of certain items in our kits, it is not unusual to have an extra screw, hotswap socket, or diode. The quantities listed in the Kit Contents section at the beginning of this guide are the true accurate number of components needed to complete the build, if you have more than the listed quantities or have some left over at the end it does not mean that you forgot something or built the kit improperly.
+Note: Boardsource often includes extras of certain items in our kits, it is not
+unusual to have an extra screw, hotswap socket, or diode. The quantities listed
+in the Kit Contents section at the beginning of this guide are the true accurate
+number of components needed to complete the build, if you have more than the
+listed quantities or have some left over at the end it does not mean that you
+forgot something or built the kit improperly.
 
 # Step 2: Assemble the PCB
 ## PCB Assembly - Install and Solder Diodes
-The first step of PCB assembly is to install the diodes. The diodes are installed on the ‘back’ of the PCB, meaning the side that faces down when it is in final typing position. In order to tell up from down on this PCB, we can look for the solder mask that indicates the diode locations as well as the square shaped pads for the hotswap sockets. That is the bottom of this PCB. 
+The first step of PCB assembly is to install the diodes. The diodes are
+installed on the ‘back’ of the PCB, meaning the side that faces down when it is
+in final typing position. In order to tell up from down on this PCB, we can look
+for the solder mask that indicates the diode locations as well as the square
+shaped pads for the hotswap sockets. That is the bottom of this PCB.
 
-Like all through-hole diode PCBs, the diodes must be bent prior to installation. If you have a diode bender, awesome, if not it is no big deal you can bend them by hand. If you want a clean look, often needle nose pliers work quite well. It really just depends on how much patience you have.
+Like all through-hole diode PCBs, the diodes must be bent prior to installation.
+If you have a diode bender, awesome, if not it is no big deal you can bend them
+by hand. If you want a clean look, often needle nose pliers work quite well. It
+really just depends on how much patience you have.
 
-Diodes are installed into the PCB resting in place inside the areas indicated by black solder mask. You’ll notice that on one side of the diode location there is a circular hole, and on the other side of the diode location there is a square shaped hole. The black/darker side of the orange and black diode go towards the square shaped hole, and the orange side of the diode goes towards the circular shaped hole. All diodes must be installed in this orientation across the entire board. Take your time and make sure they all face the correct direction prior to soldering them, as it’s easier to take your time and do it right the first time than make a mistake and have to desolder to fix it.
+Diodes are installed into the PCB resting in place inside the areas indicated by
+black solder mask. You’ll notice that on one side of the diode location there is
+a circular hole, and on the other side of the diode location there is a square
+shaped hole. The black/darker side of the orange and black diode go towards the
+square shaped hole, and the orange side of the diode goes towards the circular
+shaped hole. All diodes must be installed in this orientation across the entire
+board. Take your time and make sure they all face the correct direction prior to
+soldering them, as it’s easier to take your time and do it right the first time
+than make a mistake and have to desolder to fix it.
 
-![diode direction](https://boardsource.imgix.net/f34ec377-1124-4595-b1f0-51d311ec3127.jpg)
+![diode
+direction](https://boardsource.imgix.net/f34ec377-1124-4595-b1f0-51d311ec3127.jpg)
 
-I find it easier to do sections of the PCB rather than the entire thing at once. I place the diode into the designated place in the correct orientation, then bend the back of the legs in order to hold it in place. I do that carefully for about 10 diodes, then flip the PCB over and solder them then trim the legs. I repeat this process until all the diodes are installed.
+I find it easier to do sections of the PCB rather than the entire thing at once.
+I place the diode into the designated place in the correct orientation, then
+bend the back of the legs in order to hold it in place. I do that carefully for
+about 10 diodes, then flip the PCB over and solder them then trim the legs. I
+repeat this process until all the diodes are installed.
 
-Don’t forget the one diode near the microcontroller that doesn’t follow the same rhythm as the others, it is shown in the photo above and faces ‘sideways’ instead of vertical.
+Don’t forget the one diode near the microcontroller that doesn’t follow the same
+rhythm as the others, it is shown in the photo above and faces ‘sideways’
+instead of vertical.
 
-![diode bend](https://boardsource.imgix.net/66e89518-c5bf-46b0-8634-e4cfa6ff0ee0.jpg)
+![diode
+bend](https://boardsource.imgix.net/66e89518-c5bf-46b0-8634-e4cfa6ff0ee0.jpg)
 
-In the above photo you will see how I bend the back of the diode legs to hold them in place and allow me to flip the PCB over and solder them. I think it’s best to do this in sections because even after bending the legs they usually will move and wiggle around a bit, and I like to make sure the diode is fully seated against the PCB to make it all look cleaner. Plus, it can be difficult to navigate the field of bent diode legs with your soldering iron, so doing it in sections is best and easiest.
+In the above photo you will see how I bend the back of the diode legs to hold
+them in place and allow me to flip the PCB over and solder them. I think it’s
+best to do this in sections because even after bending the legs they usually
+will move and wiggle around a bit, and I like to make sure the diode is fully
+seated against the PCB to make it all look cleaner. Plus, it can be difficult to
+navigate the field of bent diode legs with your soldering iron, so doing it in
+sections is best and easiest.
 
-![diode complete](https://boardsource.imgix.net/af595f07-8971-4d8c-a154-b46b00ecb411.jpg)
+![diode
+complete](https://boardsource.imgix.net/af595f07-8971-4d8c-a154-b46b00ecb411.jpg)
 
-Now that we have successfully installed all the diodes, as shown in the photo above, we are ready to move on to the next step.
+Now that we have successfully installed all the diodes, as shown in the photo
+above, we are ready to move on to the next step.
 
 ## PCB Assembly - Install Hotswap Sockets
-Next, we will install the hotswap sockets. Hotswap sockets are installed onto the PCB on the same side as the diodes, the “back” of the PCB.
+Next, we will install the hotswap sockets. Hotswap sockets are installed onto
+the PCB on the same side as the diodes, the “back” of the PCB.
 
-The pads match up for the hotswaps no matter the direction you face the socket, however, you’ll notice that one direction causes the socket to overlap the hole for the switch post. Make sure to not install the hot swaps in such a way where it covers up the switch post, that is the wrong orientation. Take a look at the photo below to see what I mean.
+The pads match up for the hotswaps no matter the direction you face the socket,
+however, you’ll notice that one direction causes the socket to overlap the hole
+for the switch post. Make sure to not install the hot swaps in such a way where
+it covers up the switch post, that is the wrong orientation. Take a look at the
+photo below to see what I mean.
 
-![socket installation](https://boardsource.imgix.net/a329846c-9d99-4a18-b632-71e00b51a958.jpg)
+![socket
+installation](https://boardsource.imgix.net/a329846c-9d99-4a18-b632-71e00b51a958.jpg)
 
-Go through the entire PCB and install all hotswap sockets in the necessary location and solder them into place. I usually like to fill the entire “well” of the socket, as sometimes when installing switches the hotswap will take a significant amount of pressure and you don’t want it to break off under pressure. Careful not to over-fill though.
+Go through the entire PCB and install all hotswap sockets in the necessary
+location and solder them into place. I usually like to fill the entire “well” of
+the socket, as sometimes when installing switches the hotswap will take a
+significant amount of pressure and you don’t want it to break off under
+pressure. Careful not to over-fill though.
 
 #### Very Important: You must install the hotswap sockets in the middle area of the microcontroller prior to installing the microcontroller or they will be covered up.
 
-![socket in controller area](https://boardsource.imgix.net/42796bee-a754-4359-a7b7-e5a2057fc8ed.jpg)
+![socket in controller
+area](https://boardsource.imgix.net/42796bee-a754-4359-a7b7-e5a2057fc8ed.jpg)
 
-Now that you’ve installed every socket onto the PCB, and you have made sure to install the sockets that will soon be hidden by the microcontroller, you’re PCB should look like this.
+Now that you’ve installed every socket onto the PCB, and you have made sure to
+install the sockets that will soon be hidden by the microcontroller, you’re PCB
+should look like this.
 
-![sockets done](https://boardsource.imgix.net/809d2412-91b5-4d67-ae18-571064ce121a.jpg)
+![sockets
+done](https://boardsource.imgix.net/809d2412-91b5-4d67-ae18-571064ce121a.jpg)
 
 # Step 3: Install Controller
 ## Install Controller - Install Header Pins Into PCB
-The first step of installing the microcontroller is to install the header pins into the PCB. This is fairly easy and there is only thing to look out for — which side of the pins you put through the PCB. 
+The first step of installing the microcontroller is to install the header pins
+into the PCB. This is fairly easy and there is only thing to look out for —
+which side of the pins you put through the PCB.
 
-If you take a look at the header pins, you’ll notice that there is a black piece of plastic on the pins, and the pins on one side of the black plastic are shorter than the other side. The shorter side is what you connect the microcontroller to, and the longer side is what goes through the PCB.
+If you take a look at the header pins, you’ll notice that there is a black piece
+of plastic on the pins, and the pins on one side of the black plastic are
+shorter than the other side. The shorter side is what you connect the
+microcontroller to, and the longer side is what goes through the PCB.
 
-![controller legs](https://boardsource.imgix.net/651d2577-0163-452a-9bf6-f4d1e79c9c08.jpg)
+![controller
+legs](https://boardsource.imgix.net/651d2577-0163-452a-9bf6-f4d1e79c9c08.jpg)
 
-Make sure to solder the header pins into the PCB while the pins are completely flat against the PCB and the black plastic is firmly seated against the PCB, and the pins are totally perpendicular to the PCB. If they are installed unevenly or crooked the microcontroller will not properly fit.
+Make sure to solder the header pins into the PCB while the pins are completely
+flat against the PCB and the black plastic is firmly seated against the PCB, and
+the pins are totally perpendicular to the PCB. If they are installed unevenly or
+crooked the microcontroller will not properly fit.
 
-After you’ve successfully soldered the header pins into the PCB, trim the excess legs on the opposite (front) side of the PCB as flush as you can with the face of the PCB. Please remember, these legs can fly very far and very fast when you cut them, so be sure to cover your eyes and preferably block them from flying so you don’t step on them later.
+After you’ve successfully soldered the header pins into the PCB, trim the excess
+legs on the opposite (front) side of the PCB as flush as you can with the face
+of the PCB. Please remember, these legs can fly very far and very fast when you
+cut them, so be sure to cover your eyes and preferably block them from flying so
+you don’t step on them later.
 
-Here is how the front of the PCB will look after you flush-cut the legs of the header pins.
+Here is how the front of the PCB will look after you flush-cut the legs of the
+header pins.
 
-![controller legs snipped](https://boardsource.imgix.net/42626948-3a0a-4608-b2ec-29dac1d2dcb3.jpg)
+![controller legs
+snipped](https://boardsource.imgix.net/42626948-3a0a-4608-b2ec-29dac1d2dcb3.jpg)
 
 ## Install Controller - Solder the Controller In Place
-Note: It is always a good idea to try and flash your microcontroller prior to installing it onto the PCB, as they are incredibly difficulty to de-solder and replace. It is very rare but sometimes microcontrollers do not work and are dead on arrival, so it’s best to figure that out prior to soldered it.
+Note: It is always a good idea to try and flash your microcontroller prior to
+installing it onto the PCB, as they are incredibly difficulty to de-solder and
+replace. It is very rare but sometimes microcontrollers do not work and are dead
+on arrival, so it’s best to figure that out prior to soldered it.
 
-Now that the header pins for the microcontroller are installed into the PCB you can solder the microcontroller into place. On this PCB, the components on the Pro Micro or Elite-C face up. The side of the controller with “more stuff” on it will facing up and visible, the blank side (or side with the Elite-C logo) will be facing down and hidden.
+Now that the header pins for the microcontroller are installed into the PCB you
+can solder the microcontroller into place. On this PCB, the components on the
+Pro Micro or Elite-C face up. The side of the controller with “more stuff” on it
+will facing up and visible, the blank side (or side with the Elite-C logo) will
+be facing down and hidden.
 
 ## IMPORTANT NOTE
-**If the area underneath your controller on the backside of the PCB says 'Face Up' then you have the new version of the PCB with edits made. These edits make it so that the micro controller is installed with the components face up on the PCB. The old version of the PCB which does NOT say 'Face Up' must have the controller installed face down with the blank side up. If you need help determining which version of the PCB you have please reach out on Discord. Sorry for any inconveniences this may cause.**
+**If the area underneath your controller on the backside of the PCB says 'Face
+Up' then you have the new version of the PCB with edits made. These edits make
+it so that the micro controller is installed with the components face up on the
+PCB. The old version of the PCB which does NOT say 'Face Up' must have the
+controller installed face down with the blank side up. If you need help
+determining which version of the PCB you have please reach out on Discord. Sorry
+for any inconveniences this may cause.**
 
-![controller soldered](https://boardsource.imgix.net/3ce3a7bb-d1f1-4449-be9d-ebaf149c14c6.jpg)
+![controller
+soldered](https://boardsource.imgix.net/3ce3a7bb-d1f1-4449-be9d-ebaf149c14c6.jpg)
 
-This photo was taken at a different time than the rest of the build guide, and the build guide was produced for the first version of the PCB. The only thing that has changed is the orientation of the controller. All other photos showing the controller may be inaccurate depending on your version of the PCB. If you need help please reach out on Discord. If you received your package after Sep 15th 2020 it is extremely likely you have the new version of the PCB and must install the controller with the components face up, disregard any photo showing anything different.
+This photo was taken at a different time than the rest of the build guide, and
+the build guide was produced for the first version of the PCB. The only thing
+that has changed is the orientation of the controller. All other photos showing
+the controller may be inaccurate depending on your version of the PCB. If you
+need help please reach out on Discord. If you received your package after Sep
+15th 2020 it is extremely likely you have the new version of the PCB and must
+install the controller with the components face up, disregard any photo showing
+anything different.
 
 # Step 4: Install Reset Switch
-Before being totally finished with the PCB assembly and all the soldering, we must install the reset switch. The reset switch is installed on the back of the PCB, the same side as the diodes, hot swaps, and microcontroller.
+Before being totally finished with the PCB assembly and all the soldering, we
+must install the reset switch. The reset switch is installed on the back of the
+PCB, the same side as the diodes, hot swaps, and microcontroller.
 
-The best method to do this that I have found is to fill the holes with solder, and then re-heat the solder and install the switch.
+The best method to do this that I have found is to fill the holes with solder,
+and then re-heat the solder and install the switch.
 
 First, fill the holes so they look like this.
 
-![reset footprint tinned](https://boardsource.imgix.net/7627a4c2-792f-49d6-9f93-cf9cf9181d6e.jpg)
+![reset footprint
+tinned](https://boardsource.imgix.net/7627a4c2-792f-49d6-9f93-cf9cf9181d6e.jpg)
 
-Next, you can simply hold the switch in place with needle nose pliers or tweezers, and heat the filled hole on one side while applying light pressure to the switch. This should re-flow the solder in that hole and at least make a bit of contact with the reset switch’s legs. If you can’t really tell if contact has been made or it seems a bit loose, you can add a bit of solder on afterwards. Make sure to do both sides of the reset switch.
+Next, you can simply hold the switch in place with needle nose pliers or
+tweezers, and heat the filled hole on one side while applying light pressure to
+the switch. This should re-flow the solder in that hole and at least make a bit
+of contact with the reset switch’s legs. If you can’t really tell if contact has
+been made or it seems a bit loose, you can add a bit of solder on afterwards.
+Make sure to do both sides of the reset switch.
 
 When you’re done, it will look like this.
 
-![reset switch installed](https://boardsource.imgix.net/c552b5d0-69b4-4c4d-b557-a8e4ef51d4da.jpg)
+![reset switch
+installed](https://boardsource.imgix.net/c552b5d0-69b4-4c4d-b557-a8e4ef51d4da.jpg)
 
 #### With all of the above steps done, we have a completed PCB and we are done soldering! Here is a photo of how the completed soldering will look.
 
-![pcb assembly done](https://boardsource.imgix.net/a082ba7c-8ac6-4f1c-9331-d5120a6707da.jpg)
+![pcb assembly
+done](https://boardsource.imgix.net/a082ba7c-8ac6-4f1c-9331-d5120a6707da.jpg)
 
 # Step 5: Install Switches
-With the PCB completely assembled, we can move onto installing the switches into the plate. 
+With the PCB completely assembled, we can move onto installing the switches into
+the plate.
 
-![switches and plate](https://boardsource.imgix.net/8258db24-41fb-464d-969a-16c4292ac830.jpg)
+![switches and
+plate](https://boardsource.imgix.net/8258db24-41fb-464d-969a-16c4292ac830.jpg)
 
-Install a switch into each switch hole in the plate. Make sure that the direction of the switch legs is consistent. Take a look at this photo to see how it’s done.
+Install a switch into each switch hole in the plate. Make sure that the
+direction of the switch legs is consistent. Take a look at this photo to see how
+it’s done.
 
-![switches orientation](https://boardsource.imgix.net/239ba10e-4b56-4b24-a267-e4d3eafdcdbb.jpg)
+![switches
+orientation](https://boardsource.imgix.net/239ba10e-4b56-4b24-a267-e4d3eafdcdbb.jpg)
 
 # Step 6: Install Threaded Spacers into PCB
-Find 5 of the threaded spacers provided in your kit and 5 of the M2 screws. Depending on the color of the Case selected in your kit, your hardware will either be silver or black.
+Find 5 of the threaded spacers provided in your kit and 5 of the M2 screws.
+Depending on the color of the Case selected in your kit, your hardware will
+either be silver or black.
 
-Connect the threaded spacers to the PCB as shown below. The spacer should protrude from the back of the PCB, and the screws will go in from the front of the PCB where the switches sit.
+Connect the threaded spacers to the PCB as shown below. The spacer should
+protrude from the back of the PCB, and the screws will go in from the front of
+the PCB where the switches sit.
 
-![pcb with threaded standoffs installed](https://boardsource.imgix.net/cda49351-3b0e-4334-9c5b-37515d2818c4.jpg)
+![pcb with threaded standoffs
+installed](https://boardsource.imgix.net/cda49351-3b0e-4334-9c5b-37515d2818c4.jpg)
 
 # Step 7: Make the Switch Sandwich
-With the PCB assembly totally done, everything soldered, the threaded spacers installed onto the PCB, and the switches placed into the plate, we can join the plate (with switches) to the PCB.
+With the PCB assembly totally done, everything soldered, the threaded spacers
+installed onto the PCB, and the switches placed into the plate, we can join the
+plate (with switches) to the PCB.
 
-Before doing this, make sure that all the switch legs are facing the same direction, and that they are not bent. If they are bent they will not seat properly into the hotswap socket. Visualize how the switch legs will be inserted into the hotswap socket to ensure proper orientation. 
+Before doing this, make sure that all the switch legs are facing the same
+direction, and that they are not bent. If they are bent they will not seat
+properly into the hotswap socket. Visualize how the switch legs will be inserted
+into the hotswap socket to ensure proper orientation.
 
-Line everything up and push firmly but don’t force it, the switch legs should begin to go into the hotswap sockets. Go around the entirety of the board and make sure that each switch is properly seated into the PCB’s hotswap sockets.
+Line everything up and push firmly but don’t force it, the switch legs should
+begin to go into the hotswap sockets. Go around the entirety of the board and
+make sure that each switch is properly seated into the PCB’s hotswap sockets.
 
-Note: If you do not feel comfotable doing the sandwich technique all at once, just install a few switches around the edges of the plate and maybe a few in the middle area, connect the plate to the PCB with only those switches installed, then go around and do the remaining switches one by one. I just prefer to do them all at once and I ‘have the feel for it now,’ but for some people it’s best to do it one by one.
+Note: If you do not feel comfotable doing the sandwich technique all at once,
+just install a few switches around the edges of the plate and maybe a few in the
+middle area, connect the plate to the PCB with only those switches installed,
+then go around and do the remaining switches one by one. I just prefer to do
+them all at once and I ‘have the feel for it now,’ but for some people it’s best
+to do it one by one.
 
-![plate with switches sandwiched against pcb](https://boardsource.imgix.net/8bfc24d6-7f6b-4053-b460-ebac19cc0634.jpg)
+![plate with switches sandwiched against
+pcb](https://boardsource.imgix.net/8bfc24d6-7f6b-4053-b460-ebac19cc0634.jpg)
 
 # Step 8: Install the Backplate
-After you’re fairly certain each switch is installed properly and the legs are seated in the hotswap socket, you can connect the back plate. Use the remaining screws to attach the backplate to the threaded spacers. 
+After you’re fairly certain each switch is installed properly and the legs are
+seated in the hotswap socket, you can connect the back plate. Use the remaining
+screws to attach the backplate to the threaded spacers.
 
 Place the rubber feet onto the backplate.
 
-![back plate installation](https://boardsource.imgix.net/f6ce3d58-11f5-4dce-82d4-0ec09e8de514.jpg)
+![back plate
+installation](https://boardsource.imgix.net/f6ce3d58-11f5-4dce-82d4-0ec09e8de514.jpg)
 
 ## All done!
 
-![completed build](https://boardsource.imgix.net/2215c60d-a809-4e95-aeb2-8ce6b9ca3a43.jpg)
+![completed
+build](https://boardsource.imgix.net/2215c60d-a809-4e95-aeb2-8ce6b9ca3a43.jpg)
 
-Now that we have successfully built the board, we can work on making our keymap and flashing the board! Refer to [this guide](https://boardsource.xyz/help/5efaa7fcb4d8f617980f5fba) if you need help flashing the board.
+Now that we have successfully built the board, we can work on making our keymap
+and flashing the board! Refer to [this
+guide](https://boardsource.xyz/help/5efaa7fcb4d8f617980f5fba) if you need help
+flashing the board.
 
-I hope you enjoy your board! If you’ve run into issues, come get some help in the Help channel in [our Discord](https://discord.gg/FTun6Cy), or [Submit A Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account section of Boardsource.
+I hope you enjoy your board! If you’ve run into issues, come get some help in
+the Help channel in [our Discord](https://discord.gg/FTun6Cy), or [Submit A
+Ticket](https://boardsource.xyz/my-account/submit-a-ticket) in the My Account
+section of Boardsource.
 
+### QMK
+In qmk this keyboard can be found under boardsource/ortho.
+the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working
+from an existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
+### KMK / PEG
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
 
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
+Here are some links to other articles that may help you get the most out of your
+new keyboard:
+* Get the most out of your PCB [Unleashing the High-Tech Power of Custom
+  Keyboards](https://new.boardsource.xyz/docs/articles-features)
+* [Keyboard
+  Programing](https://new.boardsource.xyz/docs/guides-keyboard_programing)
 
-
-
-
-
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/osprette.md
+++ b/build_guides/osprette.md
@@ -22,9 +22,9 @@ https://i.imgur.com/Ba753EB.jpg
 | SMD Diodes | 34 |
 | PCB | 1 |
 | Primicro style controller or similar microcontroller | 1 |
-| Reset Switch | 1 | 
-| MX Hotswap Sockets | 34 | 
-| MX Switches | 34 | 
+| Reset Switch | 1 |
+| MX Hotswap Sockets | 34 |
+| MX Switches | 34 |
 | MX Keycaps | 34 |
 
 ![components](https://i.imgur.com/6ruYhWJ.jpg)
@@ -32,33 +32,36 @@ https://i.imgur.com/Ba753EB.jpg
 # Soldering
 ## Diodes
 **Orientation**: Black bar facing downwards or towards the footprint indicator.
-1. Solder one pad.
-![one pad - diode](https://i.imgur.com/OubXsXj.jpg)
+1. Solder one pad. ![one pad - diode](https://i.imgur.com/OubXsXj.jpg)
 2. While holding diode with tweezers, reflow solder and place diode down on pad.
 ![diode placed](https://i.imgur.com/g42HnV6.jpg)
-3. Solder other pad.
-![diode complete](https://i.imgur.com/H5R0JUJ.jpg)
-- Note, when working with [MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package diodes,
-you may need to reflow and add more solder a couple times before an adequate connection is made.
+3. Solder other pad. ![diode complete](https://i.imgur.com/H5R0JUJ.jpg)
+- Note, when working with
+[MELF](https://en.wikipedia.org/wiki/Metal_electrode_leadless_face) package
+diodes, you may need to reflow and add more solder a couple times before an
+adequate connection is made.
 
 
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/wiyyDLt.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/e0ZyFbM.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/4XTt1cq.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/wiyyDLt.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/e0ZyFbM.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/4XTt1cq.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: microcontroller face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/sg8zp6c.jpg)
-2. Place microcontroller face down. 
-![microcontroller placed](https://i.imgur.com/yzRhqMn.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/sg8zp6c.jpg)
+2. Place microcontroller face down. ![microcontroller
+placed](https://i.imgur.com/yzRhqMn.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/DY1dRP0.jpg)
@@ -66,29 +69,38 @@ you may need to reflow and add more solder a couple times before an adequate con
 ## Misc.
 
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/ijFXro0.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/5c9V0Vy.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/ijFXro0.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/5c9V0Vy.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under QMKKEYBOARDNAME.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under QMKKEYBOARDNAME. #TODO
+To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
 
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/reviung41.md
+++ b/build_guides/reviung41.md
@@ -14,25 +14,26 @@ banner: https://boardsource.imgix.net/ea77f3f8-6cc4-4cb4-a801-cf58b5af8fcc.jpg
 thumbnail: https://boardsource.imgix.net/3fa9c28c-70af-4ed4-b3d0-f46b64302461.jpg?auto=format&ixlib=react-9.2.0&q=80&w=300&dpr=1
 ---
 # REVIUNG41 Build Guide
-![REVIUNG41 Keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-01-1536x1026.jpg)
+![REVIUNG41
+Keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-01-1536x1026.jpg)
 ## build guide
 ## Parts included in the kit
-| name                      | number | remarks                         |
+| name | number | remarks |
 |---------------------------|--------|---------------------------------|
-| PCBs                      | 1      | Main PCB                        |
-| Top plate (PCB)           | 1      | PCB with switch mounting holes  |
-| bottom plate              | 1      | FR4                             |
-| ProMicro protection plate | 1      | acrylic                         |
-| acrylic nuts and bolts    | 3      | steel nuts and bolts            |
-| case stand offs 8mm       | 11     | aluminum stand offs             |
-| M2 screw 4mm              | 22     | For top/bottom plate connection |
-| rubber foot               | 6      | for bottom plate                |
-| Diode (1N4148 SMD)        | 41     |                                 |
-| MX Hotswaps               | 41     |                                 |
-| Tact switch               | 1      | reset switch                    |
-| Tact switch               | 11     |                                 |
-| Durock 2U stabalizer kit  | 1      |                                 |
-|                           |        |                                 |
+| PCBs | 1 | Main PCB |
+| Top plate (PCB) | 1 | PCB with switch mounting holes |
+| bottom plate | 1 | FR4 |
+| ProMicro protection plate | 1 | acrylic |
+| acrylic nuts and bolts | 3 | steel nuts and bolts |
+| case stand offs 8mm | 11 | aluminum stand offs |
+| M2 screw 4mm | 22 | For top/bottom plate connection |
+| rubber foot | 6 | for bottom plate |
+| Diode (1N4148 SMD) | 41 | |
+| MX Hotswaps | 41 | |
+| Tact switch | 1 | reset switch |
+| Tact switch | 11 | |
+| Durock 2U stabalizer kit | 1 | |
+|                           | | |
 ## Required parts other than the kit
 | [Pro Micro](https://boardsource.xyz/store/628b95b494dfa308a6581622) compatible MCU | 1  |  
 
@@ -44,7 +45,8 @@ thumbnail: https://boardsource.imgix.net/3fa9c28c-70af-4ed4-b3d0-f46b64302461.jp
 ## assembly
 The general flow is as follows.
     
-1. First prepare the ProMicro and write the firmware. [Flashing guide](https://boardsource.xyz/help/5efaa7fcb4d8f617980f5fba)
+1. First prepare the ProMicro and write the firmware. [Flashing
+   guide](https://boardsource.xyz/help/5efaa7fcb4d8f617980f5fba)
 
 2. Solder the reset switch.
 
@@ -64,45 +66,19 @@ The general flow is as follows.
 
 10. Attach the keycaps and you are done.
 
-![pcb front before](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-1-1280x855.jpg)
+![pcb front
+before](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-1-1280x855.jpg)
 ### pcb front before soldering
-![pcb front after](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-3-1280x855.jpg)
+![pcb front
+after](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-3-1280x855.jpg)
 ### pcb front after soldering
-![pcb back before](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-2-1280x855.jpg)
+![pcb back
+before](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-2-1280x855.jpg)
 ### pcb back before soldering
-![pcb back after](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-4-1280x855.jpg)
+![pcb back
+after](https://reviung.com/wp-content/uploads/2020/01/reviung41-pcb-4-1280x855.jpg)
 ### pcb back after soldering 
 
-
-## Preporation for ProMicro
-### **Build a build environment on your PC**
-----
-[A] Download and install QMK Toolbox.
-
->[https://github.com/qmk/qmk_toolbox/](https://github.com/qmk/qmk_toolbox/)
-
->[download](https://github.com/qmk/qmk_toolbox/releases
-)
-
-You can download the default .hex file here.
-
-
->reviung41_default_via.hex_.zip (REMAP supported)
- reviung41_default.hex_.zip　(REMAP not supported)
-[https://qmk.fm/keyboards/](https://qmk.fm/keyboards/)
-
-
-[B] If you want to edit the keymap yourself, clone the firmware below and build it.
-
->[https://github.com/qmk/qmk_firmware](https://github.com/qmk/qmk_firmware)
-
-If you clone the QMK firmware, the directory is "qmk_firmware/keyboards/reviung41/"
-Please refer to the QMK Firmware documentation for the build method.
-
->[QMK Firmware documentation
-](https://docs.qmk.fm/)
-
- ## Once the firmware build environment is ready, prepare to connect the ProMicro to your PC.
 
 ---
 Solder the through (spring pin header) to the ProMicro. (Recommendation)
@@ -111,160 +87,189 @@ Alternatively, solder the pin headers to the ProMicro.
 
 ### There is a recommended mounting direction for the con-through.
 ----
-Conthrough has a  side with a hole   and   a side without a hole   , and   there is a side with a hole closer to the pin and a side farther from the pin.a
+Conthrough has a side with a hole and a side without a hole , and there is a
+side with a hole closer to the pin and a side farther from the pin.a
 
-When mounting, make sure   **that the two small windows face the same direction , and insert the hole closer to the pin into the ProMicro**
+When mounting, make sure **that the two small windows face the same direction ,
+and insert the hole closer to the pin into the ProMicro**
 
-Stick the through through the side of the ProMicro chip and solder it from the other side.
+Stick the through through the side of the ProMicro chip and solder it from the
+other side.
 
-Soldering is only on the ProMicro and the through side.
-Do not solder the PCB and the con-through.
-![pro micro headerpin mointing](https://reviung.com/wp-content/uploads/2020/01/Pro-Micro-1-1280x855.jpg)
-![pro micro headerpin soldered underside](https://reviung.com/wp-content/uploads/2020/01/Pro-Micro-2-1280x855.jpg)
+Soldering is only on the ProMicro and the through side. Do not solder the PCB
+and the con-through. ![pro micro headerpin
+mointing](https://reviung.com/wp-content/uploads/2020/01/Pro-Micro-1-1280x855.jpg)
+![pro micro headerpin soldered
+underside](https://reviung.com/wp-content/uploads/2020/01/Pro-Micro-2-1280x855.jpg)
 
 ## When using a pin header
 ---
-Even if you use a normal pin header instead of a through hole, pierce the pin header on the surface where the ProMicro chip is mounted and solder it.
+Even if you use a normal pin header instead of a through hole, pierce the pin
+header on the surface where the ProMicro chip is mounted and solder it.
 
 Also, if you use a pin header, solder the PCB side as well.
 
 ## Soldering the reset switch
 ---
-Then solder the reset switch to the PCB.
-Solder the tact switch to the part marked "RESET" on the back of the PCB.
-*Refer to the photo of the soldering completion image (back side of PCB) when soldering
-![reset switch soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-reset-1-1280x855.jpg)
+Then solder the reset switch to the PCB. Solder the tact switch to the part
+marked "RESET" on the back of the PCB. *Refer to the photo of the soldering
+completion image (back side of PCB) when soldering ![reset switch
+soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-reset-1-1280x855.jpg)
 
-![back of reset switch soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-reset-2-1280x855.jpg)
+![back of reset switch
+soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-reset-2-1280x855.jpg)
 
-Attach the ProMicro to the PCB, connect it to your PC with a USB cable, and prepare to write the firmware.
-
-## Write firmware to ProMicro
----
-Write the .hex file to ProMicro.  Burn using
-[QMK ToolBox](https://github.com/qmk/qmk_toolbox/releases) make reviung41:default:avrdude or burn with command.
-
-Press the reset button to reset the ProMicro (into writable bootloader mode) when flashing the firmware.
-
-After writing is completed, disconnect the USB cable from the PC once.
+Attach the ProMicro to the PCB, connect it to your PC with a USB cable, and
+prepare to write the firmware.
 
 ## Solder the LEDs while checking the operation one by one.
 ---
 Solder the LED (WS2812B).
 
-![LED WS2812B](https://reviung.com/wp-content/uploads/2020/01/WS2812B-1280x855.jpg)
+![LED
+WS2812B](https://reviung.com/wp-content/uploads/2020/01/WS2812B-1280x855.jpg)
 The REVIUN41 uses a 5050 size chip called [WS2812B].
 
-Use a soldering iron with a temperature control function and work at a temperature of about 320°C.
-(If the temperature is too low, it will take time for the solder to melt, making the work difficult.)
+Use a soldering iron with a temperature control function and work at a
+temperature of about 320°C. (If the temperature is too low, it will take time
+for the solder to melt, making the work difficult.)
 
-First, there is an LED installation pad marked "L1" on the upper right side of the back of the PCB, so we will attach the LEDs in order from here.
+First, there is an LED installation pad marked "L1" on the upper right side of
+the back of the PCB, so we will attach the LEDs in order from here.
 
-*In PCB ver1.2, the letter "1" of L1 is hidden by a via (hole), but please refer to the position of the photo.
+*In PCB ver1.2, the letter "1" of L1 is hidden by a via (hole), but please refer
+to the position of the photo.
 
-  *In PCB ver1.4 and later, all LEDs are placed in the same direction. The orientation is different from the photo. Please follow the silk printed on the PCB.
+  *In PCB ver1.4 and later, all LEDs are placed in the same direction. The
+  orientation is different from the photo. Please follow the silk printed on the
+  PCB.
 
-![LED SITTING ON PCB](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-1-1280x855.jpg)
+![LED SITTING ON
+PCB](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-1-1280x855.jpg)
 
 
-The LEDs on the back of the PCB are attached in clockwise order from "L1" to "L10".
-"L11" is in the center of the surface and will be soldered last.
-  Note that the directions of the LEDs are different for [L1/L2/L9/L10 on the top of the PCB], [L3/L8 on the middle], and [L4/L5/L6/L7 on the bottom].
+The LEDs on the back of the PCB are attached in clockwise order from "L1" to
+"L10". "L11" is in the center of the surface and will be soldered last. Note
+that the directions of the LEDs are different for [L1/L2/L9/L10 on the top of
+the PCB], [L3/L8 on the middle], and [L4/L5/L6/L7 on the bottom].
 1. Apply flux to the pads on the backside of the PCB.
 
 2. Next, pre-solder only one of the four pads.
 
-If you are right-handed, pre-soldering the lower right pad will make the work easier.)
+If you are right-handed, pre-soldering the lower right pad will make the work
+easier.)
 
-Put a little solder on the warmed "tip" and apply it to the pad.
-If you have applied too much, apply a dry (wiped off the solder) soldering iron to the solder piled up on the pad, and the excess solder will move to the tip of the soldering iron.
+Put a little solder on the warmed "tip" and apply it to the pad. If you have
+applied too much, apply a dry (wiped off the solder) soldering iron to the
+solder piled up on the pad, and the excess solder will move to the tip of the
+soldering iron.
 
 3. Apply flux to the preliminary solder.
 
-4. Align and place the LED (WS2812B) using tweezers so that the GND mark on the PCB and the VSS of the LED are aligned.
-(Place it so that the GND ▲ mark on the PCB matches the position where the △ of the LED is missing.)
+4. Align and place the LED (WS2812B) using tweezers so that the GND mark on the
+PCB and the VSS of the LED are aligned. (Place it so that the GND ▲ mark on the
+PCB matches the position where the △ of the LED is missing.)
 
 ![LED DRAWING](https://reviung.com/wp-content/uploads/2020/01/WS2812B-V5_V1.jpg)
-![LED PLACEMENT](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-2-1280x855.jpg)
-5. While holding the LED in place with tweezers, apply the soldering iron to the spare solder that you just made and fix the LED.
+![LED
+PLACEMENT](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-2-1280x855.jpg)
+5. While holding the LED in place with tweezers, apply the soldering iron to the
+   spare solder that you just made and fix the LED.
 
-At this time, work for 2 to 3 seconds so as not to apply the soldering iron too much.
-Also, be careful not to touch the LED body with the tip of the soldering iron.
+At this time, work for 2 to 3 seconds so as not to apply the soldering iron too
+much. Also, be careful not to touch the LED body with the tip of the soldering
+iron.
 
-Look at the PCB from the side and check if the LED contacts are floating.
-It is a success if the contact of the LED is exactly on the PCB and fixed.
+Look at the PCB from the side and check if the LED contacts are floating. It is
+a success if the contact of the LED is exactly on the PCB and fixed.
 
-If the position of the LED is misaligned from the four corner marks (silk/print), or if it is not fixed well, wait until the LED cools down and then recover it.
+If the position of the LED is misaligned from the four corner marks
+(silk/print), or if it is not fixed well, wait until the LED cools down and then
+recover it.
 
 6. Next, solder other pads and LEDs.
 
-Put a small amount of solder on the "trowel" and apply solder to the pad.
-Also at this time, work for about 2 seconds so as not to apply the soldering iron too much.
+Put a small amount of solder on the "trowel" and apply solder to the pad. Also
+at this time, work for about 2 seconds so as not to apply the soldering iron too
+much.
 
-As an image, instead of applying solder to both sides of the LED and fixing it, it will be an image that the solder is soaked into the pad of the PCB and the pad surface of the LED (as if sending it thinly).
+As an image, instead of applying solder to both sides of the LED and fixing it,
+it will be an image that the solder is soaked into the pad of the PCB and the
+pad surface of the LED (as if sending it thinly).
 * Be careful not to float the LED due to the thickness of the solder.
 
-Once you've attached one, wait for the LED to cool down, then move on to soldering the next pad.
+Once you've attached one, wait for the LED to cool down, then move on to
+soldering the next pad.
 
-![LED SOLDERED](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-3-1280x855.jpg)
+![LED
+SOLDERED](https://reviung.com/wp-content/uploads/2020/01/reviung41-led-3-1280x855.jpg)
 
 After soldering the four points, clean the flux with a flux cleaner.
 
-After soldering the LED of "L1", connect the ProMicro and PC with a USB cable and check if the LED lights up.
-If it lights up, it's a success.
+After soldering the LED of "L1", connect the ProMicro and PC with a USB cable
+and check if the LED lights up. If it lights up, it's a success.
 
 If it doesn't light up, it could be one of the following:
 
-bad soldering
-out of position
-Broken LED
-Forgot to write firmware
+bad soldering out of position Broken LED Forgot to write firmware
 
-**When recovering,   be sure to remove the USB from the PC before working.**
+**When recovering, be sure to remove the USB from the PC before working.**
 
-In the case of poor soldering, it may be difficult to see visually.
-Try reheating the solder attached to the LED and pad.
-After reapplying flux to the four solder points on the LED that does not glow, apply the soldering iron to each point for about 2 seconds to remelt the solder.
-After working one place, wait for the LED to cool down and reheat the solder on the next pad in the same way.
+In the case of poor soldering, it may be difficult to see visually. Try
+reheating the solder attached to the LED and pad. After reapplying flux to the
+four solder points on the LED that does not glow, apply the soldering iron to
+each point for about 2 seconds to remelt the solder. After working one place,
+wait for the LED to cool down and reheat the solder on the next pad in the same
+way.
 
 If the LED is misaligned or floating, don't panic and recover the soldering.
-Apply flux again and work for 1-2 seconds without applying too much soldering iron.
+Apply flux again and work for 1-2 seconds without applying too much soldering
+iron.
 
-If the LED is damaged, absorb the solder with a solder wick, then use a soldering iron set at about 320° to heat the LED from the sides while carefully peeling it off with tweezers.
-At this time, if the LED is pulled strongly upward, the pad may come off.
-Slide the LED sideways with a soldering iron and tweezers or lead pliers, or carefully destroy the LED and remove it from the PCB so as not to damage the PCB.
+If the LED is damaged, absorb the solder with a solder wick, then use a
+soldering iron set at about 320° to heat the LED from the sides while carefully
+peeling it off with tweezers. At this time, if the LED is pulled strongly
+upward, the pad may come off. Slide the LED sideways with a soldering iron and
+tweezers or lead pliers, or carefully destroy the LED and remove it from the PCB
+so as not to damage the PCB.
 
-When the "L1" LED comes on, next work on the "L2" LED to check if it lights up, and then work in numerical order until "L11". (L11 is on the surface)
+When the "L1" LED comes on, next work on the "L2" LED to check if it lights up,
+and then work in numerical order until "L11". (L11 is on the surface)
 
-  **Be sure to disconnect the USB before soldering. There is a risk of short circuit.**
+  **Be sure to disconnect the USB before soldering. There is a risk of short
+  circuit.**
 
 ## Soldering the diodes
 ---
-There is a diode mounting position above the switch mounting position, so solder 41 points.
+There is a diode mounting position above the switch mounting position, so solder
+41 points.
 
-The mounting direction of the diode is fixed.
-Mount the diode so that the "|" mark on the chip part faces the "|" side of the diode mark "▹|" on the PCB.
+The mounting direction of the diode is fixed. Mount the diode so that the "|"
+mark on the chip part faces the "|" side of the diode mark "▹|" on the PCB.
 
-Solder while paying attention to the mounting direction.
-The temperature of the soldering iron is about 320°.
-A small amount of solder is sufficient.
+Solder while paying attention to the mounting direction. The temperature of the
+soldering iron is about 320°. A small amount of solder is sufficient.
 
 ![dioed](https://reviung.com/wp-content/uploads/2020/01/diode-1280x855.jpg)
-![dioed on pcb](https://reviung.com/wp-content/uploads/2020/01/reviung41-diode-1-1280x855.jpg)
+![dioed on
+pcb](https://reviung.com/wp-content/uploads/2020/01/reviung41-diode-1-1280x855.jpg)
 1. Flux the pads (both) first.
 
 2. Next, apply preliminary solder to one of the pads.
 
-If your dominant hand is right-handed, it may be easier to work from the right pad.
+If your dominant hand is right-handed, it may be easier to work from the right
+pad.
 
 3. Use tweezers to align and place the diode.
 
-While holding the diode with tweezers so that it does not shift, apply the soldering iron to the preliminary soldering to fix the diode.
-Look at the PCB from the side to see if the diode is floating.
+While holding the diode with tweezers so that it does not shift, apply the
+soldering iron to the preliminary soldering to fix the diode. Look at the PCB
+from the side to see if the diode is floating.
 
 Four. Then solder the other side.
 
-![dioed complete](https://reviung.com/wp-content/uploads/2020/01/reviung41-diode-2-1280x855.jpg)
+![dioed
+complete](https://reviung.com/wp-content/uploads/2020/01/reviung41-diode-2-1280x855.jpg)
 
 After soldering, remove the flux with a flux cleaning solution.
 
@@ -272,119 +277,168 @@ After soldering, remove the flux with a flux cleaning solution.
 ---
 Solder 41 sockets for switch connection.
 
-1. Apply flux to the pad and insert the socket.
-*Sockets also have mounting directions. If you attach it in the opposite direction, it will block the hole in the center of the switch, so please be careful of the orientation.
+1. Apply flux to the pad and insert the socket. *Sockets also have mounting
+directions. If you attach it in the opposite direction, it will block the hole
+in the center of the switch, so please be careful of the orientation.
 
 2. Solder the terminals on one side.
 
-Have tweezers handy as you will need to switch from "thread solder" to tweezers on the way.
+Have tweezers handy as you will need to switch from "thread solder" to tweezers
+on the way.
 
-Place a trowel on the socket terminal and the edge of the pad and heat for 2-3 seconds.
-Next, apply "thread solder" from the inside of the terminal to the vicinity of the iron tip, and melt the appropriate amount (small amount) of solder.
+Place a trowel on the socket terminal and the edge of the pad and heat for 2-3
+seconds. Next, apply "thread solder" from the inside of the terminal to the
+vicinity of the iron tip, and melt the appropriate amount (small amount) of
+solder.
 
-Once the solder has permeated the pad surface, remove the solder wire (with the soldering iron still applied), switch to the tweezers, and   release the soldering iron while holding the socket so that it does not float .
+Once the solder has permeated the pad surface, remove the solder wire (with the
+soldering iron still applied), switch to the tweezers, and release the soldering
+iron while holding the socket so that it does not float .
 
-The amount of solder is small enough to penetrate the four corners of the pad (on the PCB side).
-You don't need to use a lot of solder.
+The amount of solder is small enough to penetrate the four corners of the pad
+(on the PCB side). You don't need to use a lot of solder.
 
-3. Make sure the socket is not floating before soldering the terminals on the other side.
+3. Make sure the socket is not floating before soldering the terminals on the
+   other side.
 
-Four. After soldering, clean the flux with a flux cleaner
-![HotSwap Soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-soket-1280x855.jpg)
-This completes the soldering work.
-Check the whole to make sure there are no soldering omissions or incorrect component installation directions.
+Four. After soldering, clean the flux with a flux cleaner ![HotSwap
+Soldered](https://reviung.com/wp-content/uploads/2020/01/reviung41-soket-1280x855.jpg)
+This completes the soldering work. Check the whole to make sure there are no
+soldering omissions or incorrect component installation directions.
 
 Finally, clean the remaining flux with a flux cleaning solution.
 
 ## Attach the stabilizer to the main PCB.
 ---
-Attach the stabilizer to the PCB surface.
-Install the stabilizer so that the shaft of the stabilizer faces upward, referring to the photo.
+Attach the stabilizer to the PCB surface. Install the stabilizer so that the
+shaft of the stabilizer faces upward, referring to the photo.
 
-After installation, check from the side and back that the claws of the stabilizer are firmly attached.
-*If the nail does not fit tightly, it will not fit perfectly on the top plate.
+After installation, check from the side and back that the claws of the
+stabilizer are firmly attached. *If the nail does not fit tightly, it will not
+fit perfectly on the top plate.
 
-![stabolizer installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-stabilizer-1280x855.jpg)
+![stabilizer
+installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-stabilizer-1280x855.jpg)
 
 ## Attach the ProMicro protective cover to the top plate
 ---
 Attach the ProMicro protective cover to the top plate. (not required)
 
->NOTE
-  *Tightening the screws too much may crack the acrylic parts. Tighten them properly.
+>NOTE *Tightening the screws too much may crack the acrylic parts. Tighten them
+  properly.
 
-> *A protective sheet is attached to the acrylic parts. Peel off the protective sheet before assembling.
+> *A protective sheet is attached to the acrylic parts. Peel off the protective
+> sheet before assembling.
 
-![acrylic promicro cover](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-1-1280x855.jpg)
+![acrylic promicro
+cover](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-1-1280x855.jpg)
 
-Place the spacer in the screw hole for the ProMicro protective cover in the top center of the top plate.
+Place the spacer in the screw hole for the ProMicro protective cover in the top
+center of the top plate.
 
-![spacer placement](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-2-1280x855.jpg)
+![spacer
+placement](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-2-1280x855.jpg)
 
-Align the screw holes with the spacers on the protective cover and insert the screws.
-Secure with nuts from the back side.
+Align the screw holes with the spacers on the protective cover and insert the
+screws. Secure with nuts from the back side.
 
-![acrylic promicro cover installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-3-1280x855.jpg)
+![acrylic promicro cover
+installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-PMcover-3-1280x855.jpg)
 ## Attach the top plate, [option] middle plate (top and bottom), and bottom plate.
 ---
 ### Without middle plate
 ----
 
-1. Fit the switch in the four corners of the top plate and the position of the thumb center key.
-2. Firmly fit the four corners and middle thumb key switches into the main PCB sockets.
+1. Fit the switch in the four corners of the top plate and the position of the
+   thumb center key.
+2. Firmly fit the four corners and middle thumb key switches into the main PCB
+   sockets.
 3. Engage all remaining switches.
-4. Attach screws and spacers to the bottom plate, paying attention to the front and back of the bottom plate.
-5. Place the top plate + main PCB on top of the bottom plate and screw it on to complete.
+4. Attach screws and spacers to the bottom plate, paying attention to the front
+   and back of the bottom plate.
+5. Place the top plate + main PCB on top of the bottom plate and screw it on to
+   complete.
 ### [Option] When using the middle plate and silicon sheet
-1. Paying attention to the front and back of the bottom plate, attach the screws and spacers.
+1. Paying attention to the front and back of the bottom plate, attach the screws
+   and spacers.
 
 2. [Optional] Place the middle plate (bottom) on top of the bottom plate.
 
-![bottom plate](https://reviung.com/wp-content/uploads/2020/01/reviung41-bottom-1280x855.jpg)
+![bottom
+plate](https://reviung.com/wp-content/uploads/2020/01/reviung41-bottom-1280x855.jpg)
 3. [Optional] Place the PCB on top of the middle plate (bottom).
 
-![pcb on bottom plate](https://reviung.com/wp-content/uploads/2020/01/reviung41-middle-1280x855.jpg)
-4. Place the top plate ([option] silicon sheet + middle plate (upper)) on the PCB and screw the spacers to complete.
+![pcb on bottom
+plate](https://reviung.com/wp-content/uploads/2020/01/reviung41-middle-1280x855.jpg)
+4. Place the top plate ([option] silicon sheet + middle plate (upper)) on the
+   PCB and screw the spacers to complete.
 
-![top plateinstalled](https://reviung.com/wp-content/uploads/2020/01/reviung41-top-1280x855.jpg)
+![top
+plateinstalled](https://reviung.com/wp-content/uploads/2020/01/reviung41-top-1280x855.jpg)
 
-Finally, attach the rubber feet to the four corners of the bottom plate and just below the screws above the space bar position. (5 locations in total)
+Finally, attach the rubber feet to the four corners of the bottom plate and just
+below the screws above the space bar position. (5 locations in total)
 
 ## Install the switch.
 ---
-nsert the switch into the socket from the top plate side.
-Check that the switch terminals are straight and straighten any bent ones before inserting them into the sockets.
+nsert the switch into the socket from the top plate side. Check that the switch
+terminals are straight and straighten any bent ones before inserting them into
+the sockets.
 
-If the switch is 5-pin, it may be tight (hard) to fit.
-It was tough with Gateron ink Black (5pin).
-A 3-pin switch can be attached smoothly.
+If the switch is 5-pin, it may be tight (hard) to fit. It was tough with Gateron
+ink Black (5pin). A 3-pin switch can be attached smoothly.
 
-The switches I tried were hard to fit in the following order.
-3-pin switch ＜＜ Turquoise Tealios, Zealios ＜ Gateron ink Black
+The switches I tried were hard to fit in the following order. 3-pin switch ＜＜
+Turquoise Tealios, Zealios ＜ Gateron ink Black
 
-If the switch is hard and does not fit easily, place your thumbs on top of each other and push it in firmly.
-Putting a cloth such as a towel between the switch and your thumb will make it easier to apply force so that your fingers do not hurt.
+If the switch is hard and does not fit easily, place your thumbs on top of each
+other and push it in firmly. Putting a cloth such as a towel between the switch
+and your thumb will make it easier to apply force so that your fingers do not
+hurt.
 
- ![switches installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-switch-1280x855.jpg)
+ ![switches
+ installed](https://reviung.com/wp-content/uploads/2020/01/reviung41-switch-1280x855.jpg)
  ## Attach the keycap and you are done.
 ---
-Finally, attach the keycap and you are done.
-Attach the keycap of your choice.
+Finally, attach the keycap and you are done. Attach the keycap of your choice.
 
 The bottom 5 keys are available with the following size keycaps:
 
 
-| space bar        | 2.25U | or 2U |
+| space bar | 2.25U | or 2U |
 |------------------|-------|-------|
-| 4 right and left | 1.25U | or 1U |
-![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-05-1280x855.jpg)
-![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-04-641x960.jpg)
-![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-02-1280x855.jpg)
-![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-03-1280x855.jpg)
-![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-06-1280x855.jpg)
+| 4 right and left | 1.25U | or 1U | ![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-05-1280x855.jpg) ![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-04-641x960.jpg) ![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-02-1280x855.jpg) ![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-03-1280x855.jpg) ![finished keyboard](https://reviung.com/wp-content/uploads/2020/01/reviung41-06-1280x855.jpg)
 
 That's all.
 
 good job for today.
 
 ---
+
+## Firmware
+
+### QMK
+In qmk this keyboard can be found under QMKKEYBOARDNAME. #TODO
+To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+
+
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/rhymestone.md
+++ b/build_guides/rhymestone.md
@@ -7,7 +7,7 @@ product_link: https://boardsource.xyz/store/5ecb6aee86879c9a0c22da89
 subcategory: hard
 draft: false
 tags: 
-- 60%
+- 40%
 - ergo
 - kit
 banner: https://images.boardsource.xyz/v1_images/b702ede0-e39b-4282-96bc-a3e974b25877.jpg
@@ -22,8 +22,7 @@ thumbnail: https://images.boardsource.xyz/v1_images/bed2638f-66b1-4f19-ba1e-28f0
 
 ## Kit accessories
 
-| name | number | remarks |
----- | ---- | --- |
+| name | number | remarks | ---- | ---- | --- |
 | PCB | 2 sheets | |
 | Top plate | 2 | The one with many square holes |
 | Bottom plate | 2 pieces | The one with only screw holes |
@@ -39,14 +38,12 @@ thumbnail: https://images.boardsource.xyz/v1_images/bed2638f-66b1-4f19-ba1e-28f0
 | Tact switch | 2 |
 
 ## What you need other than the kit
-| name | number | remarks |
----- | ---- | --- |
+| name | number | remarks | ---- | ---- | --- |
 | 3.5mm stereo cable (3 poles) | 1 cable | For connection between keyboards |
 | MicroUSB cable | 1 cable | For keyboard and PC connection |
 | Key Switches | 40 | MX Compatible |
 | Keycaps | 40 pcs | MX Compatible |
-| Pro Micro | 2 pcs | |
-Spring pin header 12P | 4 pcs | It's convenient for replacement and checking, so it's highly recommended.
+| Pro Micro | 2 pcs | | Spring pin header 12P | 4 pcs | It's convenient for replacement and checking, so it's highly recommended.
 | MX Sockets | 40 pcs | Sockets for MX Switches |
 | *SK6812mini* | *40 pieces* | *For backlight (optional)* |
 | *OLED module* | *1-2 pieces* | *For OLED (optional)* |
@@ -55,22 +52,15 @@ Spring pin header 12P | 4 pcs | It's convenient for replacement and checking, so
 
 
 
-#### pro micro
-
-Usually when you buy a ProMicro, it comes with a pin header, so you don't have to buy it, but if you use a spring pin header for a slightly expensive console
-
-- Recovery when the wrong side of the keyboard board is soldered
-- Countermeasures against micro baldness
-- Replacement and restoration measures for Pro Micro bricking (when abnormal data is written)
-- Reusable Pro Micro
-
-There are only merits, so I highly recommend it. If you are an expert who wants to install OLED directly, please complete the section "Land short of PCB for OLED installation" first.
-
 #### OLED and pin socket for OLED
 
-　OLED can be attached to both hands. Since the status for various operation confirmations is displayed on the left hand side, it works well even if you purchase only one side.
+　OLED can be attached to both hands. Since the status for various operation
+  confirmations is displayed on the left hand side, it works well even if you
+  purchase only one side.
 
-If you buy only OLED from AliExpress or Yusha Kobo, there is no pin socket, so please purchase separately from Akizuki Denshi or Hirosu Guinette. There are various types, but the socket
+If you buy only OLED from AliExpress or Yusha Kobo, there is no pin socket, so
+please purchase separately from Akizuki Denshi or Hirosu Guinette. There are
+various types, but the socket
 
 - 2.54mm pitch
 - Low profile board mounting height 3.5mm
@@ -80,7 +70,15 @@ If you buy only OLED from AliExpress or Yusha Kobo, there is no pin socket, so p
 "I need something."
 #### SK6812mini
 
-　The SK6812mini for the backlight is vulnerable to solder heat, and unless it is a soldering iron with a temperature control function, failures often occur and it takes a long time to damage the parts. Chinese-made soldering irons with a temperature control function are cheap, but depending on the item, the temperature may not be accurate and may damage the parts, so if possible, use temperature-controlled soldering irons from Japanese manufacturers such as HAKKO. Please use Also, the soldering tip (soldering tip) is not the pencil type that comes as standard, but it is recommended to purchase a diagonally cut type separately, as it will make a mess.
+　The SK6812mini for the backlight is vulnerable to solder heat, and unless it
+  is a soldering iron with a temperature control function, failures often occur
+  and it takes a long time to damage the parts. Chinese-made soldering irons
+  with a temperature control function are cheap, but depending on the item, the
+  temperature may not be accurate and may damage the parts, so if possible, use
+  temperature-controlled soldering irons from Japanese manufacturers such as
+  HAKKO. Please use Also, the soldering tip (soldering tip) is not the pencil
+  type that comes as standard, but it is recommended to purchase a diagonally
+  cut type separately, as it will make a mess.
 
 ## Required tools
 | Name | Remarks |
@@ -94,87 +92,117 @@ If you buy only OLED from AliExpress or Yusha Kobo, there is no pin socket, so p
 | Flux remover | Although it is not essential, it can remove the stickiness after soldering, and the yellow discoloration caused by solder can be wiped off for a clean finish. |
 | Masking tape | Used for marking and temporary fixing. 100-yen pattern is OK |
 
-　Mtei's [Memo of tools required to make a Helix keyboard kit](https://gist.github.com/mtei/6957107a676ddfa85bde0ae41f8fa849)
-And hdbx's [Tools to prepare when starting your own keyboard](https://hdbx.hateblo.jp/entry/2018/06/01/215401) will also be helpful.
+　Mtei's [Memo of tools required to make a Helix keyboard
+kit](https://gist.github.com/mtei/6957107a676ddfa85bde0ae41f8fa849) And hdbx's
+[Tools to prepare when starting your own
+keyboard](https://hdbx.hateblo.jp/entry/2018/06/01/215401) will also be helpful.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120070.jpg)
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130102.jpg)
 
 ## Preparation of promicro
 
-Please reinforce the promicro connector and solder the through pin.
-Please install the promicro so that the surface on which it is mounted faces the keyboard board.
- - Promicro's connector reinforcement: [Write QMK_Firmware while preventing promicro's moge](https://qiita.com/hdbx/items/2f3e4ddfcadda2a5578e)
- - Soldering Cons Through Pins: [Helix Beta Build Guide](https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_en.md)
+Please reinforce the promicro connector and solder the through pin. Please
+install the promicro so that the surface on which it is mounted faces the
+keyboard board.
+ - Promicro's connector reinforcement: [Write QMK_Firmware while preventing
+   promicro's moge](https://qiita.com/hdbx/items/2f3e4ddfcadda2a5578e)
+ - Soldering Cons Through Pins: [Helix Beta Build
+   Guide](https://github.com/MakotoKurauchi/helix/blob/master/Doc/buildguide_en.md)
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20190131-P1310235.jpg)
 
 ### Prepare QMK
-This keyboard is programmed to work with keyboard software called QMK. The pre-registered default keymap is actually used by the author, and is devised so that it can be used almost without any inconvenience.
+This keyboard is programmed to work with keyboard software called QMK. The
+pre-registered default keymap is actually used by the author, and is devised so
+that it can be used almost without any inconvenience.
 
 1. Install QMK Toolbox from the link below
 2. Select rhymestone from the list under "Keyboard from qmk.fm" in QMK Toolbox
-    1. (If you can't find it, download the default hex file from the link below and select "Local File")
-3. Connect the promicro (or the board if it is directly attached) to the PC and press the reset button to write.
-    1. (Some patterns cannot be written unless the reset button is double-clicked.)
+    1. (If you can't find it, download the default hex file from the link below
+       and select "Local File")
+3. Connect the promicro (or the board if it is directly attached) to the PC and
+   press the reset button to write.
+    1. (Some patterns cannot be written unless the reset button is
+       double-clicked.)
 
-Salicylic Acid's article [(Beginner Edition) Writing firmware to a self-made keyboard] (https://salicylic-acid3.hatenablog.com/entry/qmk-toolbox) will be helpful for how to write.
+Salicylic Acid's article [(Beginner Edition) Writing firmware to a self-made
+keyboard] (https://salicylic-acid3.hatenablog.com/entry/qmk-toolbox) will be
+helpful for how to write.
 
-[Default hex file](https://qmk.fm/compiled/marksard_rhymestone_default.hex)
-[QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases)
+[Default hex file](https://qmk.fm/compiled/marksard_rhymestone_default.hex) [QMK
+Toolbox](https://github.com/qmk/qmk_toolbox/releases)
 
 #### Customizing the keymap
 
-If you have no programming experience, it would be quicker to use the QMK Configurator.
+If you have no programming experience, it would be quicker to use the QMK
+Configurator.
 
-[QMK Configurator](https://docs.qmk.fm/#/en/newbs_building_firmware_configurator)
+[QMK
+Configurator](https://docs.qmk.fm/#/en/newbs_building_firmware_configurator)
 
 #### Create a build environment
-If you can build from the source by yourself, you can freely customize each key to detailed operation.
+If you can build from the source by yourself, you can freely customize each key
+to detailed operation.
 
-[Prepare the QMK build environment] (https://docs.qmk.fm/#/ja/newbs_getting_started)
+[Prepare the QMK build environment]
+(https://docs.qmk.fm/#/ja/newbs_getting_started)
 
-The default keymap for rhymestone is
-```qmk compile -kb markard/rhymestone -km default```
-is possible. if you write
-```qmk flash -kb markard/rhymestone -km default```
-Then, as soon as the compilation is completed, it will wait for writing, so in that state, click the reset button on the board or double-click to start writing.
+The default keymap for rhymestone is ```qmk compile -kb markard/rhymestone -km
+default``` is possible. if you write ```qmk flash -kb markard/rhymestone -km
+default``` Then, as soon as the compilation is completed, it will wait for
+writing, so in that state, click the reset button on the board or double-click
+to start writing.
 
 ## About the back and front of the board
 
-The side on which the key switch is mounted and faces upward during normal use is the front, and the reverse is the back.
+The side on which the key switch is mounted and faces upward during normal use
+is the front, and the reverse is the back.
 
 ## Determine the left and right sides of the board
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120073.jpg)
 
-The included board is a reversible board that can be used on either the left or right side. In order not to forget the left and right while creating, write left and right on the mask, and decide that the side you pasted is the front (the side where the key switch will be attached).
+The included board is a reversible board that can be used on either the left or
+right side. In order not to forget the left and right while creating, write left
+and right on the mask, and decide that the side you pasted is the front (the
+side where the key switch will be attached).
 
 ## Solder the diode
 
 ### bend the legs of the diode
-Bend all the legs of the diode before attaching it to the board. Try to find a jig to determine the distance between the holes in the board and bend it. I think it's good to have disposable chopsticks that are still connected.
+Bend all the legs of the diode before attaching it to the board. Try to find a
+jig to determine the distance between the holes in the board and bend it. I
+think it's good to have disposable chopsticks that are still connected.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120071.jpg)
 
-I was able to use the USB-C to USB-A conversion connector just right, so I bent two or three diodes at once.
+I was able to use the USB-C to USB-A conversion connector just right, so I bent
+two or three diodes at once.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120072.jpg)
 
 ### Soldering the diode
 
-The mounting direction of the diodes is the same for each board, so if you check one and install it, you can install the rest in the same direction. Install the diode with the black strip side facing the square of the diode mounting hole on the board.
+The mounting direction of the diodes is the same for each board, so if you check
+one and install it, you can install the rest in the same direction. Install the
+diode with the black strip side facing the square of the diode mounting hole on
+the board.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/diode.png)
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120074_2.jpg)
 
-　Insert the diode from the back side of the board on the left hand side. After inserting, screw the legs of the diode together to temporarily fix it. You can do it easily and quickly by inserting each horizontal row and soldering them together. After soldering, cut the leg from the base.
+　Insert the diode from the back side of the board on the left hand side. After
+  inserting, screw the legs of the diode together to temporarily fix it. You can
+  do it easily and quickly by inserting each horizontal row and soldering them
+  together. After soldering, cut the leg from the base.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120074.jpg)
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120075.jpg)
 
-Insert each row, solder, and cut repeatedly. Do the same for the right-hand board.
+Insert each row, solder, and cut repeatedly. Do the same for the right-hand
+board.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120077.jpg)
 
@@ -184,15 +212,24 @@ We will install a full-color chip LED on the back of the key switch.
 
 ### LED Mechanism and Connection Order
 
-　This chip LED has four terminals (lands), VCC, GND, DIN, and DOUT respectively. Did you do VCC and GND in junior high school? I think that it is good to recognize that each is a battery + and -. DIN and DOUT are lines that control the lighting pattern of the LED. DIN is the input and DOUT is the output. Multiple LEDs are controlled by connecting these DIN and DOUT in a daisy chain.
+　This chip LED has four terminals (lands), VCC, GND, DIN, and DOUT
+  respectively. Did you do VCC and GND in junior high school? I think that it is
+  good to recognize that each is a battery + and -. DIN and DOUT are lines that
+  control the lighting pattern of the LED. DIN is the input and DOUT is the
+  output. Multiple LEDs are controlled by connecting these DIN and DOUT in a
+  daisy chain.
 
-Regarding the connection order of the Rhymestone, it is wired in a spiral from the outside to the inside, starting from the end where the reset button is installed. It is safer and faster to install a few pieces → check the lighting → install a few pieces, so please install them in this order.
+Regarding the connection order of the Rhymestone, it is wired in a spiral from
+the outside to the inside, starting from the end where the reset button is
+installed. It is safer and faster to install a few pieces → check the lighting →
+install a few pieces, so please install them in this order.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/ledmap.png)
 
 ### Orient
-Install so that the front side of the LED faces the front side of the board.
-The mounting direction is the same for each board, so if you attach the first one correctly, you can imitate the rest.
+Install so that the front side of the LED faces the front side of the board. The
+mounting direction is the same for each board, so if you attach the first one
+correctly, you can imitate the rest.
 
 left hand side
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120088_2.jpg)
@@ -208,29 +245,41 @@ right hand side
 
 ### Apply flux with your right hand while pinching
 
-I didn't pinch it in the photo, but please apply flux while pinching it and move on to the next step.
+I didn't pinch it in the photo, but please apply flux while pinching it and move
+on to the next step.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120091.jpg)
 
 ### Add some solder to the tip of the soldering iron set at around 220 degrees
 
-Please set the iron tip to around 220 degrees. 270 degrees is high.
-"Put some solder on the soldering iron."
-The lands are connected by rubbing them against the lands with a feeling of piling up a little solder.
-First attach one of the four lands so that the land of the board and the land of the chip LED are as horizontal as possible. Once attached, release the tweezers and attach the remaining three in the same way.
+Please set the iron tip to around 220 degrees. 270 degrees is high. "Put some
+solder on the soldering iron." The lands are connected by rubbing them against
+the lands with a feeling of piling up a little solder. First attach one of the
+four lands so that the land of the board and the land of the chip LED are as
+horizontal as possible. Once attached, release the tweezers and attach the
+remaining three in the same way.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181212-PC120092.jpg)
 
 ### Check LED lighting
 
-I think that the firmware for checking LED operation has been written to the pro micro in advance, so please attach the pro micro by aligning the pin with the white frame on the front of the board (the side where the mask is pasted).
-"If you install it, the LED will light up." If it lights up, VCC, GND, and VIN of the four pins are properly soldered. If it doesn't light up, the main cause is that the VCC, GND, and VIN solders on the LED you just attached aren't properly soldered, or the VOUT solder you attached one before isn't soldered properly.
+I think that the firmware for checking LED operation has been written to the pro
+micro in advance, so please attach the pro micro by aligning the pin with the
+white frame on the front of the board (the side where the mask is pasted). "If
+you install it, the LED will light up." If it lights up, VCC, GND, and VIN of
+the four pins are properly soldered. If it doesn't light up, the main cause is
+that the VCC, GND, and VIN solders on the LED you just attached aren't properly
+soldered, or the VOUT solder you attached one before isn't soldered properly.
 
 ### Solder the remaining lands in the same way
 
-"After that, repeat this to add 20 on one hand and a total of 40 on both hands." I'm pretty happy that I can check the progress from time to time, and it's easy to understand where and what happened when the light doesn't turn on, so please do it steadily.
+"After that, repeat this to add 20 on one hand and a total of 40 on both hands."
+I'm pretty happy that I can check the progress from time to time, and it's easy
+to understand where and what happened when the light doesn't turn on, so please
+do it steadily.
 
-After everything is installed, the soldered area will become sticky with flux, so if you are concerned about it, wipe it off with a flux remover.
+After everything is installed, the soldered area will become sticky with flux,
+so if you are concerned about it, wipe it off with a flux remover.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130102.jpg)
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130104.jpg)
@@ -239,57 +288,79 @@ After everything is installed, the soldered area will become sticky with flux, s
 ## *(Optional) Installing OLED*
 ### PCB land short for OLED mounting
 
-On the front side of the board, I think there are 4 sets of 8 small ■ on the bottom side where the Pro Micro is attached. Short-circuit each pair with solder. The trick is to apply flux to the soldering surface of the board, put a small amount of solder on the soldering iron, apply it to the board, and remove it from the board after applying it for about 4-7 seconds. If it doesn't stick, remove the solder on the soldering iron and try again.
+On the front side of the board, I think there are 4 sets of 8 small ■ on the
+bottom side where the Pro Micro is attached. Short-circuit each pair with
+solder. The trick is to apply flux to the soldering surface of the board, put a
+small amount of solder on the soldering iron, apply it to the board, and remove
+it from the board after applying it for about 4-7 seconds. If it doesn't stick,
+remove the solder on the soldering iron and try again.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130110.jpg)
 
 ### Soldering the pin socket/pin header for OLED
 
-In order to install it straight and easily, temporarily hold it with masking tape so that it sticks straight, then flip it over and solder it.
+In order to install it straight and easily, temporarily hold it with masking
+tape so that it sticks straight, then flip it over and solder it.
 
 ## Solder the TRRS connector, tact switch
 
-In order to install it straight and easily, temporarily hold it with masking tape so that it sticks straight, then flip it over and solder it.
-　The tactile switch snaps into place, turns over and solders.
+In order to install it straight and easily, temporarily hold it with masking
+tape so that it sticks straight, then flip it over and solder it. 　The tactile
+switch snaps into place, turns over and solders.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130111.jpg)
 
 ## Snap the switch into the top plate
 
-You can solder the sockets first, but it's quicker and cleaner to fit the switches into the top plate first and then solder them after inserting the sockets into the terminals.
-Please fit your favorite switch into the top plate.
+You can solder the sockets first, but it's quicker and cleaner to fit the
+switches into the top plate first and then solder them after inserting the
+sockets into the terminals. Please fit your favorite switch into the top plate.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130105.jpg)
 
 ## Solder the MX socket
 
-First, align the top plate and PCB. Align the central protrusion on the back of the switch with the hole in the PCB and attach it.
+First, align the top plate and PCB. Align the central protrusion on the back of
+the switch with the hole in the PCB and attach it.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130107.jpg)
 
-　Mount the MX socket by aligning it with the white mark on the silk of the PCB. Make sure that the switch pins are properly inserted into the MX sockets, and snap them all together.
+　Mount the MX socket by aligning it with the white mark on the silk of the PCB.
+  Make sure that the switch pins are properly inserted into the MX sockets, and
+  snap them all together.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130109.jpg)
 
-"The rest is soldering." If you install an MX socket, you can replace the switch. There is no point in just piling it up thickly, so let the solder flow firmly between the PCB and the socket.
-Add a generous amount of solder to the tip of the soldering iron, and pour the heat into the socket as if you were attaching it to the PCB that you can see in the gap between the metal fittings of the socket.
+"The rest is soldering." If you install an MX socket, you can replace the
+switch. There is no point in just piling it up thickly, so let the solder flow
+firmly between the PCB and the socket. Add a generous amount of solder to the
+tip of the soldering iron, and pour the heat into the socket as if you were
+attaching it to the PCB that you can see in the gap between the metal fittings
+of the socket.
 
 ## Spacer installation
 
-　Peel off one side of the bottom plate's protective paper, and attach the rubber feet to the removed side. A large one and a small one are included so that they can be tilted as standard, so attach the two smaller ones to the front and the two larger ones to the back.
+　Peel off one side of the bottom plate's protective paper, and attach the
+  rubber feet to the removed side. A large one and a small one are included so
+  that they can be tilted as standard, so attach the two smaller ones to the
+  front and the two larger ones to the back.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130114.jpg)
 
-Remove the rest of the protective paper and use four 8mm spacers and four 5mm screws to screw it to the bottom plate.
-After screwing, insert the 3mm resin spacer into the 8mm spacer. This resin spacer works to prevent the PCB from sinking when replacing the switch.
+Remove the rest of the protective paper and use four 8mm spacers and four 5mm
+screws to screw it to the bottom plate. After screwing, insert the 3mm resin
+spacer into the 8mm spacer. This resin spacer works to prevent the PCB from
+sinking when replacing the switch.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130116.jpg)
 
 ## Mounting the protection panel
 
-　Install a blindfold around the Pro Micro and a plate to protect the OLED. Attach two 8mm spacers to the PCB (yellow ○ in the photo) with 5mm screws.
-Remove both protective papers from the plate and attach it to the spacer attached to the PCB with a black 4mm screw.
-There is a little play, so if it interferes with the keycap when attached, please shift it slightly.
+　Install a blindfold around the Pro Micro and a plate to protect the OLED.
+Attach two 8mm spacers to the PCB (yellow ○ in the photo) with 5mm screws.
+Remove both protective papers from the plate and attach it to the spacer
+attached to the PCB with a black 4mm screw. There is a little play, so if it
+interferes with the keycap when attached, please shift it slightly.
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181213-PC130112.jpg)
 
@@ -299,33 +370,72 @@ There is a little play, so if it interferes with the keycap when attached, pleas
 
 ## Flash keyboard firmware
 
-For those who wrote led_test for testing the LED backlight, please go back and write the default keymap.
+For those who wrote led_test for testing the LED backlight, please go back and
+write the default keymap.
 
 ## test
 
-"First, connect one to the PC and test." If you attach one at a time, it will always be recognized with your left hand, so please check if the keys are recognized with a keyboard tester app. If you have an OLED installed, the 4th line of the OLED is the switch status. It's OK if something changes.
+"First, connect one to the PC and test." If you attach one at a time, it will
+always be recognized with your left hand, so please check if the keys are
+recognized with a keyboard tester app. If you have an OLED installed, the 4th
+line of the OLED is the switch status. It's OK if something changes.
 
-"Remove ProMicro and USB."
-Connect the left and right with a TRRS cable, connect the ProMicro and USB on the left hand side, and let the PC recognize it.
-"Please check if communication is possible on the left and right."
+"Remove ProMicro and USB." Connect the left and right with a TRRS cable, connect
+the ProMicro and USB on the left hand side, and let the PC recognize it. "Please
+check if communication is possible on the left and right."
 
 ## Complete!
 
-"If everything looks fine after checking, you're done!" Please finish it to one only for you!
+"If everything looks fine after checking, you're done!" Please finish it to one
+only for you!
 
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/20181214-PC140118.jpg)
 
 ## How to replace the keyswitch
 
-Since it is difficult to remove by hand, please use a key switch extraction tool sold on amazon etc. to replace it.
+Since it is difficult to remove by hand, please use a key switch extraction tool
+sold on amazon etc. to replace it.
 
 ## How to use OLED Pro Micro protection plate for 30 key challenge
 
-Remove the top row of key switches, remove the normal protective plate, and install the protective plate for the 30-key challenge.
-　The explanation about the keymap is [here](https://github.com/marksard/qmk_firmware/blob/my_customize/keyboards/rhymestone/keymaps/like_jis_30keys/readme_jp.md)
+Remove the top row of key switches, remove the normal protective plate, and
+install the protective plate for the 30-key challenge. 　The explanation about
+the keymap is
+[here](https://github.com/marksard/qmk_firmware/blob/my_customize/keyboards/rhymestone/keymaps/like_jis_30keys/readme_jp.md)
 ![img](https://github.com/marksard/Keyboards/raw/master/rhymestone/documents/_image/30key.png)
-"At first, I'm not sure where my thumb is, but once you get used to it, it's fun!" Please try the challenge.
+"At first, I'm not sure where my thumb is, but once you get used to it, it's
+fun!" Please try the challenge.
 
 ## troubleshooting
 
-Please refer to the [Troubleshooting](https://github.com/marksard/Keyboards/blob/master/troubleshooting.md) page.
+Please refer to the
+[Troubleshooting](https://github.com/marksard/Keyboards/blob/master/troubleshooting.md)
+page.
+
+## Firmware
+
+### QMK
+In qmk this keyboard can be found under QMKKEYBOARDNAME. #TODO
+To begin, follow the [QMK setup
+guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+
+
+## Extra
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/slab_V.md
+++ b/build_guides/slab_V.md
@@ -78,12 +78,12 @@ you may need to reflow and add more solder a couple times before an adequate con
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under QMKKEYBOARDNAME.
+In qmk this keyboard can be found under QMKKEYBOARDNAME. #TODO
 To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
 For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
-In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME
+In Peg or KMK this keyboard can be found under KMKKEYBOARDNAME #TODO
 
 Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 

--- a/build_guides/sweep.md
+++ b/build_guides/sweep.md
@@ -20,11 +20,11 @@ thumbnail: https://i.imgur.com/Bgjz9pO.png
 |------|-------|
 | PCB | 2 |
 | Promicro style or similar microcontroller | 2 |
-| TRRS Jack | 2 | 
-| TRRS Cable | 1 | 
-| Reset Switch | 2 | 
-| MX Hotswap Sockets | 34 | 
-| MX Switches | 34 | 
+| TRRS Jack | 2 |
+| TRRS Cable | 1 |
+| Reset Switch | 2 |
+| MX Hotswap Sockets | 34 |
+| MX Switches | 34 |
 | *MX* Keycaps | 34 |
 
 ![components](https://i.imgur.com/TOSEbBB.jpg)
@@ -32,60 +32,71 @@ thumbnail: https://i.imgur.com/Bgjz9pO.png
 # Soldering
 
 ## Hotswap sockets
-1. Solder one pad.
-![Hot swap socket foot print soldered](https://i.imgur.com/0NiHxI1.jpg)
-2. While holding hotswap socket (fingers are fine), reflow solder and place socket down on pad.
-![Hot swap socket one pin soldered](https://i.imgur.com/aJU0Wbm.jpg)
-3. Solder other pad.
-![Hot swap socket finished](https://i.imgur.com/3T4OOt8.jpg)
-- Note, don't hesitate to use a little extra solder, as that will help secure the socket and prevent it from being ripped off.
+1. Solder one pad. ![Hot swap socket foot print
+soldered](https://i.imgur.com/0NiHxI1.jpg)
+2. While holding hotswap socket (fingers are fine), reflow solder and place
+socket down on pad. ![Hot swap socket one pin
+soldered](https://i.imgur.com/aJU0Wbm.jpg)
+3. Solder other pad. ![Hot swap socket
+finished](https://i.imgur.com/3T4OOt8.jpg)
+- Note, don't hesitate to use a little extra solder, as that will help secure
+  the socket and prevent it from being ripped off.
 
 ## Microcontrollers
 **Orientation**: Both microcontrollers face down.
-- Note, it is recommended to flash each microcontroller prior to soldering. See [firmware](#firmware) section for more.
-1. Insert headers from front, solder in from the back.
-![headers inserted](https://i.imgur.com/j0L0UKX.jpg)
-2. Place microcontroller face down. 
-![microcontroller placed](https://i.imgur.com/WXPr74c.jpg)
+- Note, it is recommended to flash each microcontroller prior to soldering. See
+  [firmware](#firmware) section for more.
+1. Insert headers from front, solder in from the back. ![headers
+inserted](https://i.imgur.com/j0L0UKX.jpg)
+2. Place microcontroller face down. ![microcontroller
+placed](https://i.imgur.com/WXPr74c.jpg)
 3. Apply solder to all pins.
 4. Use flush cutters or similar to trim excess from pins on each side.
 ![microcontroller finished](https://i.imgur.com/NEkz8Hb.jpg)
-5. Bridge pads on the back of the pcb 
-![two pads jumped](https://i.imgur.com/abjDor6.jpg)
-![jumped pads for microcontroller](https://i.imgur.com/0yCdYyN.jpg)
+5. Bridge pads on the back of the pcb ![two pads
+jumped](https://i.imgur.com/abjDor6.jpg) ![jumped pads for
+microcontroller](https://i.imgur.com/0yCdYyN.jpg)
 
 
 
 ## Misc.
 ### TRRS jacks
-1. Position TRRS jack on front of PCB and secure with tape.
-![trrs jack placed](https://i.imgur.com/RGORZIJ.jpg)
-2. Apply solder to all four pins.
-![trrs jack finished](https://i.imgur.com/V29nVRL.jpg)
+1. Position TRRS jack on front of PCB and secure with tape. ![trrs jack
+placed](https://i.imgur.com/RGORZIJ.jpg)
+2. Apply solder to all four pins. ![trrs jack
+finished](https://i.imgur.com/V29nVRL.jpg)
 ### Reset switches
-1. Solder one pad.
-![reset switch placed](https://i.imgur.com/XgvlIBi.jpg)
-2. While holding switch with tweezers, reflow solder and place switch down on pad.
-3. Solder remaining pads.
-![reset switch placed](https://i.imgur.com/6TieoFz.jpg)
+1. Solder one pad. ![reset switch placed](https://i.imgur.com/XgvlIBi.jpg)
+2. While holding switch with tweezers, reflow solder and place switch down on
+   pad.
+3. Solder remaining pads. ![reset switch
+placed](https://i.imgur.com/6TieoFz.jpg)
 
 
 
 ## Firmware
 
 ### QMK
-In qmk this keyboard can be found under ferris/sweep.
-To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
-For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+In qmk this keyboard can be found under ferris/sweep. To begin, follow the [QMK
+setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an
+existing installation, an
+[update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch)
+may be needed.) \ For flashing instructions, see
+[doc](https://docs.qmk.fm/#/newbs_flashing) or
+[video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
 
 ### KMK / PEG
 In Peg or KMK this keyboard can be found under ferris_sweep or sweep
 
-Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+Peg can be downloaded [here](https://peg.software/), and the quick start can be
+seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
 
-For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the
+quick start can be seen
+[here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
 
 
 
 ## Extra
-For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)
+For questions, ask in [Boardsource Discord
+server](https://discord.gg/5qpqbgaTYz)

--- a/build_guides/tg4x.md
+++ b/build_guides/tg4x.md
@@ -15,34 +15,83 @@ thumbnail: https://images.boardsource.xyz/v1_images/82db0daf-6a3e-41c7-b4ca-2aa5
 ---
 ## Build Guide
 
-Alrighty, so you got your tg4x stuff, but don’t know how to put it together.  I’ve finally gotten around to making this build guide, so now you’re covered.  Inside your box (depending on what you ordered), you should have 2 packages.
+Alrighty, so you got your tg4x stuff, but don’t know how to put it together.
+I’ve finally gotten around to making this build guide, so now you’re covered.
+Inside your box (depending on what you ordered), you should have 2 packages.
 ![01.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/01.jpg)
-One bag is the plates, and the pcb.  The other is your assembly kit, which contains all of the other pieces and components you need.
+One bag is the plates, and the pcb. The other is your assembly kit, which
+contains all of the other pieces and components you need.
 ![02.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/02.jpg)
-Inside your assembly kit, you’ll find 50x diodes, a reset switch, a pro micro, 8x ws2812b rgb leds, ~28x screws, 5x 5mm male/female standoffs, 13x 11mm female/female standoffs, and some little rubber feet.
+Inside your assembly kit, you’ll find 50x diodes, a reset switch, a pro micro,
+8x ws2812b rgb leds, ~28x screws, 5x 5mm male/female standoffs, 13x 11mm
+female/female standoffs, and some little rubber feet.
 ![03.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/03.jpg)
-In the other package, you’ll get a top plate, bottom plate, and a skinny little plate that you can use as a foot (to add a ~5 typing angle).  You’ll also get the pcb, where the magic happens.
+In the other package, you’ll get a top plate, bottom plate, and a skinny little
+plate that you can use as a foot (to add a ~5 typing angle). You’ll also get the
+pcb, where the magic happens.
 ![04.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/01.jpg)
- First thing you’ll want to do is bend all your diodes.  An easy way to do it consistently is to use your plates and pcb, put the diodes on top, and push all the legs down.  Then you’ve got to pull the paper off all the leads.  Next, you’re gonna put diodes in all of the diode holes.  It doesn’t matter if you put them on the top or bottom of the pcb, but make sure that they are oriented correctly.  You want the end with the black strip to go into the square holes.
+First thing you’ll want to do is bend all your diodes. An easy way to do it
+consistently is to use your plates and pcb, put the diodes on top, and push all
+the legs down. Then you’ve got to pull the paper off all the leads. Next, you’re
+gonna put diodes in all of the diode holes. It doesn’t matter if you put them on
+the top or bottom of the pcb, but make sure that they are oriented correctly.
+You want the end with the black strip to go into the square holes.
 ![05.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/05.jpg)
-The easiest way to install the diodes is to place them all in, then use masking tape to hold them in place.  Now you can flip the whole thing over, clip the legs off, and solder them all in.  I find it’s easier and looks cleaner if you clip the legs before soldering, but you could also solder first.
+The easiest way to install the diodes is to place them all in, then use masking
+tape to hold them in place. Now you can flip the whole thing over, clip the legs
+off, and solder them all in. I find it’s easier and looks cleaner if you clip
+the legs before soldering, but you could also solder first.
 ![06.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/06.jpg)
 ![07.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/07.jpg)
-Next, you want to solder in the headers for the pro micro.  You want them on the bottom of the pcb, which is the side with the big fancy graphic.  Don’t solder the pro micro on yet!  If you do, it’s gonna be really hard to solder the switches later.  I’d put the short end of the headers away from the pcb, with the long legs going through.  Then clip them flush with pcb.
+Next, you want to solder in the headers for the pro micro. You want them on the
+bottom of the pcb, which is the side with the big fancy graphic. Don’t solder
+the pro micro on yet! If you do, it’s gonna be really hard to solder the
+switches later. I’d put the short end of the headers away from the pcb, with the
+long legs going through. Then clip them flush with pcb.
 ![08.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/08.jpg)
 ![09.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/09.jpg)
-Next, solder on the leds.  There’s one on the top of the pcb, and six on the bottom.  For the one on top, you want to make sure that the white corner is facing the left side of the pcb.  The leds on the bottom of the pcb all face down to the right, except for the one on the far right, which faces the other way.
+Next, solder on the leds. There’s one on the top of the pcb, and six on the
+bottom. For the one on top, you want to make sure that the white corner is
+facing the left side of the pcb. The leds on the bottom of the pcb all face down
+to the right, except for the one on the far right, which faces the other way.
 ![10.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/10.jpg)
 ![11.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/11.jpg)
-If you have mill-max sockets, you’ll want to solder them in now.  I solder them just like diodes, so I’ll put them all in, tape over them, then solder them from the underside.
-If you don’t have the sockets, skip over this step.
+If you have mill-max sockets, you’ll want to solder them in now. I solder them
+just like diodes, so I’ll put them all in, tape over them, then solder them from
+the underside. If you don’t have the sockets, skip over this step.
 ![12.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/12.jpg)
 ![13.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/13.jpg)
-Make sure you put the stabilizers in before you start to add the switches.  Put switches in each of the corners of the top plate, then fit it into the pcb.  I also like to put switches where the stabs are.  Solder those switches into the pcb.  Now it’ll be easier to fit the rest of the switches in, and solder them.  Of course, if you’re using mill-max sockets, there’s no need to solder the switches.
+Make sure you put the stabilizers in before you start to add the switches. Put
+switches in each of the corners of the top plate, then fit it into the pcb. I
+also like to put switches where the stabs are. Solder those switches into the
+pcb. Now it’ll be easier to fit the rest of the switches in, and solder them. Of
+course, if you’re using mill-max sockets, there’s no need to solder the
+switches.
 ![14.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/14.jpg)
 ![15.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/15.jpg)
-After you’ve got all the switches installed, screw in all of the standoffs to the top plate.  There are 13 in total.  Put the bottom plate on, and screw it down.
+After you’ve got all the switches installed, screw in all of the standoffs to
+the top plate. There are 13 in total. Put the bottom plate on, and screw it
+down.
 ![16.](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/16.jpg)
 
 Now all you’ve got to do is stick on some rubber feet, and find your keycaps.
 ![finished](https://raw.githubusercontent.com/MythosMann/tg4x/master/2d-3d%20stuff/build%20guide%20pics/finished.jpg)
+
+## Firmware
+
+### QMK
+In qmk this keyboard can be found under tg4x.
+To begin, follow the [QMK setup guide](https://docs.qmk.fm/#/newbs_getting_started). (if working from an existing installation, an [update](https://docs.qmk.fm/#/newbs_git_using_your_master_branch?id=updating-your-master-branch) may be needed.) \
+For flashing instructions, see [doc](https://docs.qmk.fm/#/newbs_flashing) or [video](https://www.youtube.com/watch?v=fuBJbdCFF0Q)
+
+### KMK / PEG
+In Peg or KMK this keyboard can be found under tg4x
+
+Peg can be downloaded [here](https://peg.software/), and the quick start can be seen [here](https://peg.software/docs/Peg_Client/#quick-start-and-testing).
+
+For Kmk can be downloaded [here](https://github.com/KMKfw/kmk_firmware) and the quick start can be seen [here](http://kmkfw.io/docs/Getting_Started#tldr-quick-start-guide)
+
+
+
+## Extra
+For questions, ask in [Boardsource Discord server](https://discord.gg/5qpqbgaTYz)


### PR DESCRIPTION
Added links to build firmware pages in every build guide. Added #TODO to any keyboard that is missing support in a firmware and needs added.