### PR TITLE
Update rechteck.md

### DIFF
--- a/build_guides/rechteck.md
+++ b/build_guides/rechteck.md
@@ -135,7 +135,7 @@ Another shot from the other side.
 Do this for all 5 stabilized keys and let's install the plate on the pcb.
 
 
->*tip this is a good time to lube your stabs it really helps*
+>*tip: this is a good time to lube your stabs it really helps*
 
 
 ![plate on pcb](https://images.boardsource.xyz/install_plate.gif)
@@ -158,7 +158,7 @@ happens if the switch is miss aligned.)
 
 We recommend doing the stabilized keys first.
 
-
+>*tip: when inserting the switches, ensure they're seated in the plate fully so the plate isn't compressed against the PCB. If the plate is pushed against the PCB subsequent installed switches don't seat fully and stabs can stick*
 
 
 ![install switches](https://images.boardsource.xyz/install_switches.gif)


### PR DESCRIPTION
Proposed additional tip for installing switches. During installation of switches, pulling up on the plate can help seat choc switches so subsequent switches can be installed and stabs don't stick.